### PR TITLE
StandardDeviation Implementation & More Efficient BollingerBands

### DIFF
--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -7,7 +7,7 @@ use rand::Rng;
 use ta::indicators::{
     BollingerBands, EfficiencyRatio, ExponentialMovingAverage, FastStochastic, Maximum, Minimum,
     MoneyFlowIndex, MovingAverageConvergenceDivergence, RateOfChange, RelativeStrengthIndex,
-    SimpleMovingAverage, SlowStochastic, TrueRange,
+    SimpleMovingAverage, SlowStochastic, StandardDeviation, TrueRange,
 };
 use ta::DataItem;
 use ta::Next;
@@ -56,6 +56,7 @@ macro_rules! bench_indicators {
 bench_indicators!(
     SimpleMovingAverage,
     ExponentialMovingAverage,
+    StandardDeviation,
     BollingerBands,
     EfficiencyRatio,
     FastStochastic,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,14 +1,6 @@
 /// Returns the largest of 3 given numbers.
 pub fn max3(a: f64, b: f64, c: f64) -> f64 {
-    if a > b && a > c {
-        a
-    } else {
-        if b > c {
-            b
-        } else {
-            c
-        }
-    }
+    a.max(b).max(c)
 }
 
 #[cfg(test)]

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -4,6 +4,9 @@ pub use self::exponential_moving_average::ExponentialMovingAverage;
 mod simple_moving_average;
 pub use self::simple_moving_average::SimpleMovingAverage;
 
+mod standard_deviation;
+pub use self::standard_deviation::StandardDeviation;
+
 mod relative_strength_index;
 pub use self::relative_strength_index::RelativeStrengthIndex;
 

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -5,7 +5,7 @@ use crate::{Close, Next, Reset};
 
 /// Standard deviation (SD).
 ///
-/// Standard deviation is calculated from the last n values.
+/// Returns the standard deviation of the last n values.
 ///
 /// # Formula
 ///

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -1,0 +1,200 @@
+use std::fmt;
+
+use crate::errors::*;
+use crate::{Close, Next, Reset};
+
+/// Standard deviation (SD).
+///
+/// Standard deviation is calculated from the last n values.
+///
+/// # Formula
+///
+/// ![SD formula](https://wikimedia.org/api/rest_v1/media/math/render/svg/2845de27edc898d2a2a4320eda5f57e0dac6f650)
+///
+/// Where:
+///
+/// * _σ_ - value of standard deviation for N given probes.
+/// * _N_ - number of probes in observation.
+/// * _x<sub>i</sub>_ - i-th observed value from N elements observation.
+///
+/// # Parameters
+///
+/// * _n_ - number of periods (integer greater than 0)
+///
+/// # Example
+///
+/// ```
+/// use ta::indicators::StandardDeviation;
+/// use ta::Next;
+///
+/// let mut sd = StandardDeviation::new(3).unwrap();
+/// assert_eq!(sd.next(10.0), 0.0);
+/// assert_eq!(sd.next(20.0), 5.0);
+/// ```
+///
+/// # Links
+///
+/// * [Standard Deviation, Wikipedia](https://en.wikipedia.org/wiki/Standard_deviation)
+///
+#[derive(Debug, Clone)]
+pub struct StandardDeviation {
+    n: u32,
+    index: usize,
+    count: u32,
+    m: f64,
+    m2: f64,
+    vec: Vec<f64>,
+}
+
+impl StandardDeviation {
+    pub fn new(n: u32) -> Result<Self> {
+        match n {
+            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            _ => {
+                let std = StandardDeviation {
+                    n,
+                    index: 0,
+                    count: 0,
+                    m: 0.0,
+                    m2: 0.0,
+                    vec: vec![0.0; n as usize],
+                };
+                Ok(std)
+            }
+        }
+    }
+
+    pub(super) fn mean(&self) -> f64 {
+        self.m
+    }
+}
+
+impl Next<f64> for StandardDeviation {
+    type Output = f64;
+
+    fn next(&mut self, input: f64) -> Self::Output {
+        self.index = (self.index + 1) % (self.n as usize);
+
+        let old_val = self.vec[self.index];
+        self.vec[self.index] = input;
+
+        if self.count < self.n {
+            self.count += 1;
+            let delta = input - self.m;
+            self.m += delta / self.count as f64;
+            let delta2 = input - self.m;
+            self.m2 += delta * delta2;
+        } else {
+            let delta = input - old_val;
+            let old_m = self.m;
+            self.m += delta / self.n as f64;
+            let delta2 = input - self.m + old_val - old_m;
+            self.m2 += delta * delta2;
+        }
+
+        (self.m2 / self.count as f64).sqrt()
+    }
+}
+
+impl<'a, T: Close> Next<&'a T> for StandardDeviation {
+    type Output = f64;
+
+    fn next(&mut self, input: &'a T) -> Self::Output {
+        self.next(input.close())
+    }
+}
+
+impl Reset for StandardDeviation {
+    fn reset(&mut self) {
+        self.index = 0;
+        self.count = 0;
+        self.m = 0.0;
+        self.m2 = 0.0;
+        for i in 0..(self.n as usize) {
+            self.vec[i] = 0.0;
+        }
+    }
+}
+
+impl Default for StandardDeviation {
+    fn default() -> Self {
+        Self::new(9).unwrap()
+    }
+}
+
+impl fmt::Display for StandardDeviation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SD({})", self.n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helper::*;
+
+    test_indicator!(StandardDeviation);
+
+    #[test]
+    fn test_new() {
+        assert!(StandardDeviation::new(0).is_err());
+        assert!(StandardDeviation::new(1).is_ok());
+    }
+
+    #[test]
+    fn test_next() {
+        let mut sd = StandardDeviation::new(4).unwrap();
+        assert_eq!(sd.next(10.0), 0.0);
+        assert_eq!(sd.next(20.0), 5.0);
+        assert_eq!(round(sd.next(30.0)), 8.165);
+        assert_eq!(round(sd.next(20.0)), 7.071);
+        assert_eq!(round(sd.next(10.0)), 7.071);
+        assert_eq!(round(sd.next(100.0)), 35.355);
+    }
+
+    #[test]
+    fn test_next_with_bars() {
+        fn bar(close: f64) -> Bar {
+            Bar::new().close(close)
+        }
+
+        let mut sd = StandardDeviation::new(4).unwrap();
+        assert_eq!(sd.next(&bar(10.0)), 0.0);
+        assert_eq!(sd.next(&bar(20.0)), 5.0);
+        assert_eq!(round(sd.next(&bar(30.0))), 8.165);
+        assert_eq!(round(sd.next(&bar(20.0))), 7.071);
+        assert_eq!(round(sd.next(&bar(10.0))), 7.071);
+        assert_eq!(round(sd.next(&bar(100.0))), 35.355);
+    }
+
+    #[test]
+    fn test_next_same_values() {
+        let mut sd = StandardDeviation::new(3).unwrap();
+        assert_eq!(sd.next(4.2), 0.0);
+        assert_eq!(sd.next(4.2), 0.0);
+        assert_eq!(sd.next(4.2), 0.0);
+        assert_eq!(sd.next(4.2), 0.0);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut sd = StandardDeviation::new(4).unwrap();
+        assert_eq!(sd.next(10.0), 0.0);
+        assert_eq!(sd.next(20.0), 5.0);
+        assert_eq!(round(sd.next(30.0)), 8.165);
+
+        sd.reset();
+        assert_eq!(sd.next(20.0), 0.0);
+    }
+
+    #[test]
+    fn test_default() {
+        StandardDeviation::default();
+    }
+
+    #[test]
+    fn test_display() {
+        let sd = StandardDeviation::new(5).unwrap();
+        assert_eq!(format!("{}", sd), "SD(5)");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!   * [Moving Average Convergence Divergence (MACD)](indicators/struct.MovingAverageConvergenceDivergence.html)
 //!   * [Money Flow Index (MFI)](indicators/struct.MoneyFlowIndex.html)
 //! * Other
+//!   * [Standard Deviation (SD)](indicators/struct.StandardDeviation.html)
 //!   * [Bollinger Bands (BB)](indicators/struct.BollingerBands.html)
 //!   * [Maximum](indicators/struct.Maximum.html)
 //!   * [Minimum](indicators/struct.Minimum.html)


### PR DESCRIPTION
There were few problems with the `BollingerBands` source code.

1. The document says it uses EMA, but the actual implementation uses SMA.
2. The helper function `mean_sd`, which is used to calculate SMA and standard deviation, is very inefficient. It calculates the sum and the quadratic sum of `n` values each time `next` is called.
**Time complexity: O(n)**

The first problem was easily solved by fixing the document.

To fix the second problem, I searched for an efficient algorithm and found these:
**Time complexity: O(1)**

- https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
- https://stackoverflow.com/a/14638138

So I implemented the `StandardDeviation` indicator based on the above algorithm, and modified `BollingerBands` to use the `StandardDeviation` indicator.
The new implementation passes all the tests, including the existing `BollingerBands` tests and the new `StandardDeviation` tests.

# Benchmark results
## Previous implementation using `mean_sd`
```
test BollingerBands                     ... bench:     198,020 ns/iter (+/- 21,924)
```

## Current implementation
```
test BollingerBands                     ... bench:      77,149 ns/iter (+/- 11,341)
```

The benchmark shows that the new algorithm is approx. 2.5 times faster than the previous one.
Since the time complexity changed from O(n) to O(1), the difference will be even greater for bigger `n`s.