### PR TITLE
Use output struct instead of f64 tuple for MACD

### DIFF
--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -29,7 +29,7 @@ mod average_true_range;
 pub use self::average_true_range::AverageTrueRange;
 
 mod moving_average_convergence_divergence;
-pub use self::moving_average_convergence_divergence::MovingAverageConvergenceDivergence;
+pub use self::moving_average_convergence_divergence::{MovingAverageConvergenceDivergence, MovingAverageConvergenceDivergenceOutput};
 
 mod efficiency_ratio;
 pub use self::efficiency_ratio::EfficiencyRatio;


### PR DESCRIPTION
[For this issue.](https://github.com/greyblake/ta-rs/issues/9)

I was a little lazy and wrote a `From` implementation instead of rewriting the test fixtures from tuples.