### PR TITLE
feat: add length() for SMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### Unreleased
 
 * Implement Percentage Price Oscillator (PPO)
+* More efficient SimpleMovingAverage
 
 #### v0.2.0 - 2020-08-31
 

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -12,12 +12,12 @@ use crate::{Close, Next, Reset};
 /// Where:
 ///
 /// * _SMA<sub>t</sub>_ - value of simple moving average at a point of time _t_
-/// * _n_ - number of periods (length)
+/// * _length_ - number of periods (length)
 /// * _p<sub>t</sub>_ - input value at a point of time _t_
 ///
 /// # Parameters
 ///
-/// * _n_ - number of periods (integer greater than 0)
+/// * _length_ - number of periods (integer greater than 0)
 ///
 /// # Example
 ///
@@ -38,7 +38,7 @@ use crate::{Close, Next, Reset};
 ///
 #[derive(Debug, Clone)]
 pub struct SimpleMovingAverage {
-    n: u32,
+    length: u32,
     index: usize,
     count: u32,
     sum: f64,
@@ -46,20 +46,24 @@ pub struct SimpleMovingAverage {
 }
 
 impl SimpleMovingAverage {
-    pub fn new(n: u32) -> Result<Self> {
-        match n {
+    pub fn new(length: u32) -> Result<Self> {
+        match length {
             0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
             _ => {
                 let indicator = Self {
-                    n,
+                    length,
                     index: 0,
                     count: 0,
                     sum: 0.0,
-                    vec: vec![0.0; n as usize],
+                    vec: vec![0.0; length as usize],
                 };
                 Ok(indicator)
             }
         }
+    }
+
+    pub fn length(&self) -> u32 {
+        self.length
     }
 }
 
@@ -67,12 +71,16 @@ impl Next<f64> for SimpleMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        self.index = (self.index + 1) % (self.n as usize);
-
         let old_val = self.vec[self.index];
         self.vec[self.index] = input;
 
-        if self.count < self.n {
+        self.index = if self.index + 1 < self.length as usize {
+            self.index + 1
+        } else {
+            0
+        };
+
+        if self.count < self.length {
             self.count += 1;
         }
 
@@ -94,7 +102,7 @@ impl Reset for SimpleMovingAverage {
         self.index = 0;
         self.count = 0;
         self.sum = 0.0;
-        for i in 0..(self.n as usize) {
+        for i in 0..(self.length as usize) {
             self.vec[i] = 0.0;
         }
     }
@@ -108,7 +116,7 @@ impl Default for SimpleMovingAverage {
 
 impl fmt::Display for SimpleMovingAverage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SMA({})", self.n)
+        write!(f, "SMA({})", self.length)
     }
 }
 


### PR DESCRIPTION
This PR may be usefull to implement others indicators like CCI.

It also remove the usage of the modulo used to find the index of the next poped value.
As the result, SMA is almost three time faster on my compter (i7 6500u).

from:
```
test SimpleMovingAverage                ... bench:      62,249 ns/iter (+/- 3,553)
```
to:
```
test SimpleMovingAverage                ... bench:      22,371 ns/iter (+/- 610)
```