### PR TITLE
opti: remove usage of modulo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 #### Unreleased
 
 * Implement Percentage Price Oscillator (PPO)
+* More efficient BollingerBands
+* More efficient FastStochastic
+* More efficient SlowStochastic
+* More efficient StandardDeviation
+* More efficient Minimum
+* More efficient Maximum
 
 #### v0.2.0 - 2020-08-31
 

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -67,7 +67,6 @@ impl Next<f64> for Maximum {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        self.cur_index = (self.cur_index + 1) % (self.n as usize);
         self.vec[self.cur_index] = input;
 
         if input > self.vec[self.max_index] {
@@ -75,6 +74,12 @@ impl Next<f64> for Maximum {
         } else if self.max_index == self.cur_index {
             self.max_index = self.find_max_index();
         }
+
+        self.cur_index = if self.cur_index + 1 < self.n as usize {
+            self.cur_index + 1
+        } else {
+            0
+        };
 
         self.vec[self.max_index]
     }

--- a/src/indicators/minimum.rs
+++ b/src/indicators/minimum.rs
@@ -67,7 +67,6 @@ impl Next<f64> for Minimum {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        self.cur_index = (self.cur_index + 1) % (self.n as usize);
         self.vec[self.cur_index] = input;
 
         if input < self.vec[self.min_index] {
@@ -75,6 +74,12 @@ impl Next<f64> for Minimum {
         } else if self.min_index == self.cur_index {
             self.min_index = self.find_min_index();
         }
+
+        self.cur_index = if self.cur_index + 1 < self.n as usize {
+            self.cur_index + 1
+        } else {
+            0
+        };
 
         self.vec[self.min_index]
     }

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -73,10 +73,14 @@ impl Next<f64> for StandardDeviation {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        self.index = (self.index + 1) % (self.n as usize);
-
         let old_val = self.vec[self.index];
         self.vec[self.index] = input;
+
+        self.index = if self.index + 1 < self.n as usize {
+            self.index + 1
+        } else {
+            0
+        };
 
         if self.count < self.n {
             self.count += 1;


### PR DESCRIPTION
Remove usage of modulo to find the index of the next poped value for `Minimum`, `Maximum` and `StandardDeviation`.

Here is the benchmark with my i7 6500u:
before:
```
test Maximum                            ... bench:      75,284 ns/iter (+/- 4,688)
test Minimum                            ... bench:      77,725 ns/iter (+/- 10,071)
test StandardDeviation                  ... bench:      68,862 ns/iter (+/- 5,893)

test BollingerBands                     ... bench:      86,684 ns/iter (+/- 7,133)
test FastStochastic                     ... bench:     163,767 ns/iter (+/- 22,085)
test SlowStochastic                     ... bench:     178,034 ns/iter (+/- 12,981)
```
after:
```
test Maximum                            ... bench:      32,359 ns/iter (+/- 1,353)
test Minimum                            ... bench:      32,091 ns/iter (+/- 1,369)
test StandardDeviation                  ... bench:      36,202 ns/iter (+/- 1,989)

test BollingerBands                     ... bench:      41,592 ns/iter (+/- 1,635)
test FastStochastic                     ... bench:      72,559 ns/iter (+/- 1,773)
test SlowStochastic                     ... bench:      92,549 ns/iter (+/- 2,997)
```
