### PR TITLE
refactor: rename _n_ and _length_ by _period_, replace Vec<f64> by Box<[f64]>, etc...

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ So far there are the following indicators available.
   * Minimum
   * Maximum
   * True Range
+  * Standard Deviation (SD)
   * Average True Range (AR)
   * Efficiency Ratio (ER)
   * Bollinger Bands (BB)

--- a/src/indicators/average_true_range.rs
+++ b/src/indicators/average_true_range.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::{ExponentialMovingAverage, TrueRange};
-use crate::{Close, High, Low, Next, Reset};
+use crate::{Close, High, Low, Next, Period, Reset};
 
 /// Average true range (ATR).
 ///
@@ -12,16 +12,16 @@ use crate::{Close, High, Low, Next, Reset};
 ///
 /// # Formula
 ///
-/// ATR(length)<sub>t</sub> = EMA(length) of TR<sub>t</sub>
+/// ATR(period)<sub>t</sub> = EMA(period) of TR<sub>t</sub>
 ///
 /// Where:
 ///
-/// * _EMA(n)_ - [exponential moving average](struct.ExponentialMovingAverage.html) with smoothing period _length_
+/// * _EMA(period)_ - [exponential moving average](struct.ExponentialMovingAverage.html) with smoothing period
 /// * _TR<sub>t</sub>_ - [true range](struct.TrueRange.html) for period _t_
 ///
 /// # Parameters
 ///
-/// * _length_ - smoothing period of EMA (integer greater than 0)
+/// * _period_ - smoothing period of EMA (integer greater than 0)
 ///
 /// # Example
 ///
@@ -60,12 +60,17 @@ pub struct AverageTrueRange {
 }
 
 impl AverageTrueRange {
-    pub fn new(length: u32) -> Result<Self> {
-        let indicator = Self {
+    pub fn new(period: usize) -> Result<Self> {
+        Ok(Self {
             true_range: TrueRange::new(),
-            ema: ExponentialMovingAverage::new(length)?,
-        };
-        Ok(indicator)
+            ema: ExponentialMovingAverage::new(period)?,
+        })
+    }
+}
+
+impl Period for AverageTrueRange {
+    fn period(&self) -> usize {
+        self.ema.period()
     }
 }
 
@@ -100,7 +105,7 @@ impl Default for AverageTrueRange {
 
 impl fmt::Display for AverageTrueRange {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ATR({})", self.ema.length())
+        write!(f, "ATR({})", self.ema.period())
     }
 }
 

--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::StandardDeviation as Sd;
-use crate::{Close, Next, Reset};
+use crate::{Close, Next, Period, Reset};
 
 /// A Bollinger Bands (BB).
 /// (BB).
@@ -45,7 +45,7 @@ use crate::{Close, Next, Reset};
 /// * [Bollinger Bands, Wikipedia](https://en.wikipedia.org/wiki/Bollinger_Bands)
 #[derive(Debug, Clone)]
 pub struct BollingerBands {
-    length: u32,
+    period: usize,
     multiplier: f64,
     sd: Sd,
 }
@@ -58,23 +58,22 @@ pub struct BollingerBandsOutput {
 }
 
 impl BollingerBands {
-    pub fn new(length: u32, multiplier: f64) -> Result<Self> {
-        if multiplier <= 0.0 {
-            return Err(Error::from_kind(ErrorKind::InvalidParameter));
-        }
+    pub fn new(period: usize, multiplier: f64) -> Result<Self> {
         Ok(Self {
-            length,
+            period,
             multiplier,
-            sd: Sd::new(length)?,
+            sd: Sd::new(period)?,
         })
-    }
-
-    pub fn length(&self) -> u32 {
-        self.length
     }
 
     pub fn multiplier(&self) -> f64 {
         self.multiplier
+    }
+}
+
+impl Period for BollingerBands {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -115,7 +114,7 @@ impl Default for BollingerBands {
 
 impl fmt::Display for BollingerBands {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BB({}, {})", self.length, self.multiplier)
+        write!(f, "BB({}, {})", self.period, self.multiplier)
     }
 }
 

--- a/src/indicators/exponential_moving_average.rs
+++ b/src/indicators/exponential_moving_average.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::errors::*;
-use crate::{Close, Next, Reset};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{Close, Next, Period, Reset};
 
 /// An exponential moving average (EMA), also known as an exponentially weighted moving average
 /// (EWMA).
@@ -26,11 +26,11 @@ use crate::{Close, Next, Reset};
 ///
 /// Where:
 ///
-/// * _length_ - number of periods
+/// * _period_ - number of periods
 ///
 /// # Parameters
 ///
-/// * _length_ - number of periods (integer greater than 0)
+/// * _period_ - number of periods (integer greater than 0)
 ///
 /// # Example
 ///
@@ -52,31 +52,29 @@ use crate::{Close, Next, Reset};
 
 #[derive(Debug, Clone)]
 pub struct ExponentialMovingAverage {
-    length: u32,
+    period: usize,
     k: f64,
     current: f64,
     is_new: bool,
 }
 
 impl ExponentialMovingAverage {
-    pub fn new(length: u32) -> Result<Self> {
-        match length {
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
             0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
-            _ => {
-                let k = 2f64 / (length as f64 + 1f64);
-                let indicator = Self {
-                    length,
-                    k,
-                    current: 0f64,
-                    is_new: true,
-                };
-                Ok(indicator)
-            }
+            _ => Ok(Self {
+                period,
+                k: 2.0 / (period + 1) as f64,
+                current: 0.0,
+                is_new: true,
+            }),
         }
     }
+}
 
-    pub fn length(&self) -> u32 {
-        self.length
+impl Period for ExponentialMovingAverage {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -117,7 +115,7 @@ impl Default for ExponentialMovingAverage {
 
 impl fmt::Display for ExponentialMovingAverage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "EMA({})", self.length)
+        write!(f, "EMA({})", self.period)
     }
 }
 

--- a/src/indicators/fast_stochastic.rs
+++ b/src/indicators/fast_stochastic.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::{Maximum, Minimum};
-use crate::{Close, High, Low, Next, Reset};
+use crate::{Close, High, Low, Next, Period, Reset};
 
 /// Fast stochastic oscillator.
 ///
@@ -23,7 +23,7 @@ use crate::{Close, High, Low, Next, Reset};
 ///
 /// # Parameters
 ///
-/// * _length_ - number of periods (integer greater than 0). Default is 14.
+/// * _period_ - number of periods (integer greater than 0). Default is 14.
 ///
 /// # Example
 ///
@@ -40,23 +40,24 @@ use crate::{Close, High, Low, Next, Reset};
 /// ```
 #[derive(Debug, Clone)]
 pub struct FastStochastic {
-    length: u32,
+    period: usize,
     minimum: Minimum,
     maximum: Maximum,
 }
 
 impl FastStochastic {
-    pub fn new(length: u32) -> Result<Self> {
-        let indicator = Self {
-            length: length,
-            minimum: Minimum::new(length)?,
-            maximum: Maximum::new(length)?,
-        };
-        Ok(indicator)
+    pub fn new(period: usize) -> Result<Self> {
+        Ok(Self {
+            period,
+            minimum: Minimum::new(period)?,
+            maximum: Maximum::new(period)?,
+        })
     }
+}
 
-    pub fn length(&self) -> u32 {
-        self.length
+impl Period for FastStochastic {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -109,7 +110,7 @@ impl Default for FastStochastic {
 
 impl fmt::Display for FastStochastic {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "FAST_STOCH({})", self.length)
+        write!(f, "FAST_STOCH({})", self.period)
     }
 }
 

--- a/src/indicators/keltner_channel.rs
+++ b/src/indicators/keltner_channel.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::{AverageTrueRange, ExponentialMovingAverage};
-use crate::{Close, High, Low, Next, Reset};
+use crate::{Close, High, Low, Next, Period, Reset};
 
 /// Keltner Channel (KC).
 ///
@@ -46,7 +46,7 @@ use crate::{Close, High, Low, Next, Reset};
 /// * [Keltner channel, Wikipedia](https://en.wikipedia.org/wiki/Keltner_channel)
 #[derive(Debug, Clone)]
 pub struct KeltnerChannel {
-    length: u32,
+    period: usize,
     multiplier: f64,
     atr: AverageTrueRange,
     ema: ExponentialMovingAverage,
@@ -60,24 +60,23 @@ pub struct KeltnerChannelOutput {
 }
 
 impl KeltnerChannel {
-    pub fn new(length: u32, multiplier: f64) -> Result<Self> {
-        if multiplier <= 0.0 {
-            return Err(Error::from_kind(ErrorKind::InvalidParameter));
-        }
+    pub fn new(period: usize, multiplier: f64) -> Result<Self> {
         Ok(Self {
-            length,
+            period,
             multiplier,
-            atr: AverageTrueRange::new(length)?,
-            ema: ExponentialMovingAverage::new(length)?,
+            atr: AverageTrueRange::new(period)?,
+            ema: ExponentialMovingAverage::new(period)?,
         })
-    }
-
-    pub fn length(&self) -> u32 {
-        self.length
     }
 
     pub fn multiplier(&self) -> f64 {
         self.multiplier
+    }
+}
+
+impl Period for KeltnerChannel {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -128,7 +127,7 @@ impl Default for KeltnerChannel {
 
 impl fmt::Display for KeltnerChannel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "KC({}, {})", self.length, self.multiplier)
+        write!(f, "KC({}, {})", self.period, self.multiplier)
     }
 }
 

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -1,14 +1,14 @@
 use std::f64::INFINITY;
 use std::fmt;
 
-use crate::errors::*;
-use crate::{High, Next, Reset};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{High, Next, Period, Reset};
 
 /// Returns the highest value in a given time frame.
 ///
 /// # Parameters
 ///
-/// * _n_ - size of the time frame (integer greater than 0). Default value is 14.
+/// * _period_ - size of the time frame (integer greater than 0). Default value is 14.
 ///
 /// # Example
 ///
@@ -25,34 +25,30 @@ use crate::{High, Next, Reset};
 /// ```
 #[derive(Debug, Clone)]
 pub struct Maximum {
-    n: usize,
-    vec: Vec<f64>,
+    period: usize,
     max_index: usize,
     cur_index: usize,
+    deque: Box<[f64]>,
 }
 
 impl Maximum {
-    pub fn new(n: u32) -> Result<Self> {
-        let n = n as usize;
-
-        if n == 0 {
-            return Err(Error::from_kind(ErrorKind::InvalidParameter));
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
+            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            _ => Ok(Self {
+                period,
+                max_index: 0,
+                cur_index: 0,
+                deque: vec![-INFINITY; period].into_boxed_slice(),
+            }),
         }
-
-        let indicator = Self {
-            n,
-            vec: vec![-INFINITY; n],
-            max_index: 0,
-            cur_index: 0,
-        };
-        Ok(indicator)
     }
 
     fn find_max_index(&self) -> usize {
         let mut max = -INFINITY;
         let mut index: usize = 0;
 
-        for (i, &val) in self.vec.iter().enumerate() {
+        for (i, &val) in self.deque.iter().enumerate() {
             if val > max {
                 max = val;
                 index = i;
@@ -63,25 +59,31 @@ impl Maximum {
     }
 }
 
+impl Period for Maximum {
+    fn period(&self) -> usize {
+        self.period
+    }
+}
+
 impl Next<f64> for Maximum {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        self.vec[self.cur_index] = input;
+        self.deque[self.cur_index] = input;
 
-        if input > self.vec[self.max_index] {
+        if input > self.deque[self.max_index] {
             self.max_index = self.cur_index;
         } else if self.max_index == self.cur_index {
             self.max_index = self.find_max_index();
         }
 
-        self.cur_index = if self.cur_index + 1 < self.n as usize {
+        self.cur_index = if self.cur_index + 1 < self.period {
             self.cur_index + 1
         } else {
             0
         };
 
-        self.vec[self.max_index]
+        self.deque[self.max_index]
     }
 }
 
@@ -95,8 +97,8 @@ impl<T: High> Next<&T> for Maximum {
 
 impl Reset for Maximum {
     fn reset(&mut self) {
-        for i in 0..self.n {
-            self.vec[i] = -INFINITY;
+        for i in 0..self.period {
+            self.deque[i] = -INFINITY;
         }
     }
 }
@@ -109,7 +111,7 @@ impl Default for Maximum {
 
 impl fmt::Display for Maximum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MAX({})", self.n)
+        write!(f, "MAX({})", self.period)
     }
 }
 

--- a/src/indicators/money_flow_index.rs
+++ b/src/indicators/money_flow_index.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 use std::fmt;
 
-use crate::errors::*;
-use crate::{Close, High, Low, Next, Reset, Volume};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{Close, High, Low, Next, Period, Reset, Volume};
 
 /// Money Flow Index (MFI).
 ///
@@ -28,7 +28,7 @@ use crate::{Close, High, Low, Next, Reset, Volume};
 ///
 /// # Parameters
 ///
-/// * _n_ - number of periods, integer greater than 0
+/// * _period_ - number of periods, integer greater than 0
 ///
 /// # Example
 ///
@@ -53,7 +53,7 @@ use crate::{Close, High, Low, Next, Reset, Volume};
 
 #[derive(Debug, Clone)]
 pub struct MoneyFlowIndex {
-    n: u32,
+    period: usize,
     money_flows: VecDeque<f64>,
     prev_typical_price: f64,
     total_positive_money_flow: f64,
@@ -62,21 +62,24 @@ pub struct MoneyFlowIndex {
 }
 
 impl MoneyFlowIndex {
-    pub fn new(n: u32) -> Result<Self> {
-        match n {
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
             0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
-            _ => {
-                let indicator = Self {
-                    n,
-                    money_flows: VecDeque::with_capacity(n as usize + 1),
-                    prev_typical_price: 0.0,
-                    total_positive_money_flow: 0.0,
-                    total_absolute_money_flow: 0.0,
-                    is_new: true,
-                };
-                Ok(indicator)
-            }
+            _ => Ok(Self {
+                period,
+                money_flows: VecDeque::with_capacity(period + 1),
+                prev_typical_price: 0.0,
+                total_positive_money_flow: 0.0,
+                total_absolute_money_flow: 0.0,
+                is_new: true,
+            }),
         }
+    }
+}
+
+impl Period for MoneyFlowIndex {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -105,7 +108,7 @@ impl<T: High + Low + Close + Volume> Next<&T> for MoneyFlowIndex {
 
             self.total_absolute_money_flow += money_flow;
 
-            if self.money_flows.len() == (self.n as usize) {
+            if self.money_flows.len() == self.period {
                 let old_signed_money_flow = self.money_flows.pop_front().unwrap();
                 if old_signed_money_flow > 0.0 {
                     self.total_positive_money_flow -= old_signed_money_flow;
@@ -132,7 +135,7 @@ impl Default for MoneyFlowIndex {
 
 impl fmt::Display for MoneyFlowIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MFI({})", self.n)
+        write!(f, "MFI({})", self.period)
     }
 }
 

--- a/src/indicators/moving_average_convergence_divergence.rs
+++ b/src/indicators/moving_average_convergence_divergence.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::ExponentialMovingAverage as Ema;
-use crate::{Close, Next, Reset};
+use crate::{Close, Next, Period, Reset};
 
 /// Moving average converge divergence (MACD).
 ///
@@ -22,9 +22,9 @@ use crate::{Close, Next, Reset};
 ///
 /// # Parameters
 ///
-/// * _fast_length_ - length for the fast EMA. Default is 12.
-/// * _slow_length_ - length for the slow EMA. Default is 26.
-/// * _signal_length_ - length for the signal EMA. Default is 9.
+/// * _fast_period_ - period for the fast EMA. Default is 12.
+/// * _slow_period_ - period for the slow EMA. Default is 26.
+/// * _signal_period_ - period for the signal EMA. Default is 9.
 ///
 /// # Example
 ///
@@ -56,13 +56,12 @@ pub struct MovingAverageConvergenceDivergence {
 }
 
 impl MovingAverageConvergenceDivergence {
-    pub fn new(fast_length: u32, slow_length: u32, signal_length: u32) -> Result<Self> {
-        let indicator = Self {
-            fast_ema: Ema::new(fast_length)?,
-            slow_ema: Ema::new(slow_length)?,
-            signal_ema: Ema::new(signal_length)?,
-        };
-        Ok(indicator)
+    pub fn new(fast_period: usize, slow_period: usize, signal_period: usize) -> Result<Self> {
+        Ok(Self {
+            fast_ema: Ema::new(fast_period)?,
+            slow_ema: Ema::new(slow_period)?,
+            signal_ema: Ema::new(signal_period)?,
+        })
     }
 }
 
@@ -91,9 +90,9 @@ impl Next<f64> for MovingAverageConvergenceDivergence {
         let histogram = macd - signal;
 
         MovingAverageConvergenceDivergenceOutput {
-            macd: macd,
-            signal: signal,
-            histogram: histogram,
+            macd,
+            signal,
+            histogram,
         }
     }
 }
@@ -125,9 +124,9 @@ impl fmt::Display for MovingAverageConvergenceDivergence {
         write!(
             f,
             "MACD({}, {}, {})",
-            self.fast_ema.length(),
-            self.slow_ema.length(),
-            self.signal_ema.length()
+            self.fast_ema.period(),
+            self.slow_ema.period(),
+            self.signal_ema.period(),
         )
     }
 }

--- a/src/indicators/percentage_price_oscillator.rs
+++ b/src/indicators/percentage_price_oscillator.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::ExponentialMovingAverage as Ema;
-use crate::{Close, Next, Reset};
+use crate::{Close, Next, Period, Reset};
 
 /// Percentage Price Oscillator (PPO).
 ///
@@ -22,9 +22,9 @@ use crate::{Close, Next, Reset};
 ///
 /// # Parameters
 ///
-/// * _fast_length_ - length for the fast EMA. Default is 12.
-/// * _slow_length_ - length for the slow EMA. Default is 26.
-/// * _signal_length_ - length for the signal EMA. Default is 9.
+/// * _fast_period_ - period for the fast EMA. Default is 12.
+/// * _slow_period_ - period for the slow EMA. Default is 26.
+/// * _signal_period_ - period for the signal EMA. Default is 9.
 ///
 /// # Example
 ///
@@ -56,11 +56,11 @@ pub struct PercentagePriceOscillator {
 }
 
 impl PercentagePriceOscillator {
-    pub fn new(fast_length: u32, slow_length: u32, signal_length: u32) -> Result<Self> {
-        Ok(PercentagePriceOscillator {
-            fast_ema: Ema::new(fast_length)?,
-            slow_ema: Ema::new(slow_length)?,
-            signal_ema: Ema::new(signal_length)?,
+    pub fn new(fast_period: usize, slow_period: usize, signal_period: usize) -> Result<Self> {
+        Ok(Self {
+            fast_ema: Ema::new(fast_period)?,
+            slow_ema: Ema::new(slow_period)?,
+            signal_ema: Ema::new(signal_period)?,
         })
     }
 }
@@ -124,9 +124,9 @@ impl fmt::Display for PercentagePriceOscillator {
         write!(
             f,
             "PPO({}, {}, {})",
-            self.fast_ema.length(),
-            self.slow_ema.length(),
-            self.signal_ema.length()
+            self.fast_ema.period(),
+            self.slow_ema.period(),
+            self.signal_ema.period(),
         )
     }
 }

--- a/src/indicators/relative_strength_index.rs
+++ b/src/indicators/relative_strength_index.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use crate::errors::*;
+use crate::errors::Result;
 use crate::indicators::ExponentialMovingAverage as Ema;
-use crate::{Close, Next, Reset};
+use crate::{Close, Next, Period, Reset};
 
 /// The relative strength index (RSI).
 ///
@@ -47,7 +47,7 @@ use crate::{Close, Next, Reset};
 ///
 /// # Parameters
 ///
-/// * _n_ - number of periods (integer greater than 0). Default value is 14.
+/// * _period_ - number of periods (integer greater than 0). Default value is 14.
 ///
 /// # Example
 ///
@@ -68,7 +68,7 @@ use crate::{Close, Next, Reset};
 ///
 #[derive(Debug, Clone)]
 pub struct RelativeStrengthIndex {
-    n: u32,
+    period: usize,
     up_ema_indicator: Ema,
     down_ema_indicator: Ema,
     prev_val: f64,
@@ -76,15 +76,20 @@ pub struct RelativeStrengthIndex {
 }
 
 impl RelativeStrengthIndex {
-    pub fn new(n: u32) -> Result<Self> {
-        let rsi = Self {
-            n,
-            up_ema_indicator: Ema::new(n)?,
-            down_ema_indicator: Ema::new(n)?,
+    pub fn new(period: usize) -> Result<Self> {
+        Ok(Self {
+            period,
+            up_ema_indicator: Ema::new(period)?,
+            down_ema_indicator: Ema::new(period)?,
             prev_val: 0.0,
             is_new: true,
-        };
-        Ok(rsi)
+        })
+    }
+}
+
+impl Period for RelativeStrengthIndex {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -140,7 +145,7 @@ impl Default for RelativeStrengthIndex {
 
 impl fmt::Display for RelativeStrengthIndex {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RSI({})", self.n)
+        write!(f, "RSI({})", self.period)
     }
 }
 

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::errors::*;
-use crate::{Close, Next, Reset};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{Close, Next, Period, Reset};
 
 /// Simple moving average (SMA).
 ///
@@ -12,12 +12,12 @@ use crate::{Close, Next, Reset};
 /// Where:
 ///
 /// * _SMA<sub>t</sub>_ - value of simple moving average at a point of time _t_
-/// * _length_ - number of periods (length)
+/// * _period_ - number of periods (period)
 /// * _p<sub>t</sub>_ - input value at a point of time _t_
 ///
 /// # Parameters
 ///
-/// * _length_ - number of periods (integer greater than 0)
+/// * _period_ - number of periods (integer greater than 0)
 ///
 /// # Example
 ///
@@ -38,32 +38,31 @@ use crate::{Close, Next, Reset};
 ///
 #[derive(Debug, Clone)]
 pub struct SimpleMovingAverage {
-    length: u32,
+    period: usize,
     index: usize,
-    count: u32,
+    count: usize,
     sum: f64,
-    vec: Vec<f64>,
+    deque: Box<[f64]>,
 }
 
 impl SimpleMovingAverage {
-    pub fn new(length: u32) -> Result<Self> {
-        match length {
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
             0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
-            _ => {
-                let indicator = Self {
-                    length,
-                    index: 0,
-                    count: 0,
-                    sum: 0.0,
-                    vec: vec![0.0; length as usize],
-                };
-                Ok(indicator)
-            }
+            _ => Ok(Self {
+                period,
+                index: 0,
+                count: 0,
+                sum: 0.0,
+                deque: vec![0.0; period].into_boxed_slice(),
+            }),
         }
     }
+}
 
-    pub fn length(&self) -> u32 {
-        self.length
+impl Period for SimpleMovingAverage {
+    fn period(&self) -> usize {
+        self.period
     }
 }
 
@@ -71,16 +70,16 @@ impl Next<f64> for SimpleMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        let old_val = self.vec[self.index];
-        self.vec[self.index] = input;
+        let old_val = self.deque[self.index];
+        self.deque[self.index] = input;
 
-        self.index = if self.index + 1 < self.length as usize {
+        self.index = if self.index + 1 < self.period {
             self.index + 1
         } else {
             0
         };
 
-        if self.count < self.length {
+        if self.count < self.period {
             self.count += 1;
         }
 
@@ -102,8 +101,8 @@ impl Reset for SimpleMovingAverage {
         self.index = 0;
         self.count = 0;
         self.sum = 0.0;
-        for i in 0..(self.length as usize) {
-            self.vec[i] = 0.0;
+        for i in 0..self.period {
+            self.deque[i] = 0.0;
         }
     }
 }
@@ -116,7 +115,7 @@ impl Default for SimpleMovingAverage {
 
 impl fmt::Display for SimpleMovingAverage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SMA({})", self.length)
+        write!(f, "SMA({})", self.period)
     }
 }
 

--- a/src/indicators/slow_stochastic.rs
+++ b/src/indicators/slow_stochastic.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::errors::Result;
 use crate::indicators::{ExponentialMovingAverage, FastStochastic};
-use crate::{Close, High, Low, Next, Reset};
+use crate::{Close, High, Low, Next, Period, Reset};
 
 /// Slow stochastic oscillator.
 ///
@@ -10,8 +10,8 @@ use crate::{Close, High, Low, Next, Reset};
 ///
 /// # Parameters
 ///
-/// * _stochastic_n_ - number of periods for fast stochastic (integer greater than 0). Default is 14.
-/// *_ema_n_ - length for EMA (integer greater than 0). Default is 3.
+/// * _stochastic_period_ - number of periods for fast stochastic (integer greater than 0). Default is 14.
+/// *_ema_period_ - period for EMA (integer greater than 0). Default is 3.
 ///
 /// # Example
 ///
@@ -33,12 +33,11 @@ pub struct SlowStochastic {
 }
 
 impl SlowStochastic {
-    pub fn new(stochastic_n: u32, ema_n: u32) -> Result<Self> {
-        let indicator = Self {
-            fast_stochastic: FastStochastic::new(stochastic_n)?,
-            ema: ExponentialMovingAverage::new(ema_n)?,
-        };
-        Ok(indicator)
+    pub fn new(stochastic_period: usize, ema_period: usize) -> Result<Self> {
+        Ok(Self {
+            fast_stochastic: FastStochastic::new(stochastic_period)?,
+            ema: ExponentialMovingAverage::new(ema_period)?,
+        })
     }
 }
 
@@ -76,8 +75,8 @@ impl fmt::Display for SlowStochastic {
         write!(
             f,
             "SLOW_STOCH({}, {})",
-            self.fast_stochastic.length(),
-            self.ema.length()
+            self.fast_stochastic.period(),
+            self.ema.period(),
         )
     }
 }

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use crate::errors::*;
-use crate::{Close, Next, Reset};
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{Close, Next, Period, Reset};
 
 /// Standard deviation (SD).
 ///
@@ -14,12 +14,12 @@ use crate::{Close, Next, Reset};
 /// Where:
 ///
 /// * _σ_ - value of standard deviation for N given probes.
-/// * _N_ - number of probes in observation.
+/// * _period_ - number of probes in observation.
 /// * _x<sub>i</sub>_ - i-th observed value from N elements observation.
 ///
 /// # Parameters
 ///
-/// * _n_ - number of periods (integer greater than 0)
+/// * _period_ - number of periods (integer greater than 0)
 ///
 /// # Example
 ///
@@ -38,29 +38,26 @@ use crate::{Close, Next, Reset};
 ///
 #[derive(Debug, Clone)]
 pub struct StandardDeviation {
-    n: u32,
+    period: usize,
     index: usize,
-    count: u32,
+    count: usize,
     m: f64,
     m2: f64,
-    vec: Vec<f64>,
+    deque: Box<[f64]>,
 }
 
 impl StandardDeviation {
-    pub fn new(n: u32) -> Result<Self> {
-        match n {
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
             0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
-            _ => {
-                let std = StandardDeviation {
-                    n,
-                    index: 0,
-                    count: 0,
-                    m: 0.0,
-                    m2: 0.0,
-                    vec: vec![0.0; n as usize],
-                };
-                Ok(std)
-            }
+            _ => Ok(Self {
+                period,
+                index: 0,
+                count: 0,
+                m: 0.0,
+                m2: 0.0,
+                deque: vec![0.0; period].into_boxed_slice(),
+            }),
         }
     }
 
@@ -69,20 +66,26 @@ impl StandardDeviation {
     }
 }
 
+impl Period for StandardDeviation {
+    fn period(&self) -> usize {
+        self.period
+    }
+}
+
 impl Next<f64> for StandardDeviation {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {
-        let old_val = self.vec[self.index];
-        self.vec[self.index] = input;
+        let old_val = self.deque[self.index];
+        self.deque[self.index] = input;
 
-        self.index = if self.index + 1 < self.n as usize {
+        self.index = if self.index + 1 < self.period {
             self.index + 1
         } else {
             0
         };
 
-        if self.count < self.n {
+        if self.count < self.period {
             self.count += 1;
             let delta = input - self.m;
             self.m += delta / self.count as f64;
@@ -91,7 +94,7 @@ impl Next<f64> for StandardDeviation {
         } else {
             let delta = input - old_val;
             let old_m = self.m;
-            self.m += delta / self.n as f64;
+            self.m += delta / self.period as f64;
             let delta2 = input - self.m + old_val - old_m;
             self.m2 += delta * delta2;
         }
@@ -114,8 +117,8 @@ impl Reset for StandardDeviation {
         self.count = 0;
         self.m = 0.0;
         self.m2 = 0.0;
-        for i in 0..(self.n as usize) {
-            self.vec[i] = 0.0;
+        for i in 0..self.period {
+            self.deque[i] = 0.0;
         }
     }
 }
@@ -128,7 +131,7 @@ impl Default for StandardDeviation {
 
 impl fmt::Display for StandardDeviation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SD({})", self.n)
+        write!(f, "SD({})", self.period)
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,6 +6,11 @@ pub trait Reset {
     fn reset(&mut self);
 }
 
+/// Return the period used by the indicator.
+pub trait Period {
+    fn period(&self) -> usize;
+}
+
 /// Consumes a data item of type `T` and returns `Output`.
 ///
 /// Typically `T` can be `f64` or a struct similar to [DataItem](struct.DataItem.html), that implements


### PR DESCRIPTION
Hi o/

This PR do 6 things:
 - unify the `new` function (always the same pattern)
 - replace the implicites `::*` imports by the specifics ones
 - rename all `n` (or `length`) values by `period`
 - set all `period` values as `usize`
 - implement a `Period` trait which contain a getter for the `period` value
 - replace all `Vec<f64>` by a fixed `Box<[f64]>` array


Depending of the indicator, `period` was sometime called `n` or `length` and was set as `u32` or `usize`.
This PR unify this behavior by naming all period as `period` with an `usize` type.


Also, for the indicators:
 - minimum
 - maximum
 - standard_deviation
 - simple_moving_average

We replace the `Vec<f64>` by a fixed `Box<[f64]>` since our deques are not dynamically sized after the initialization of the indicators.


It may also have sense to get rid of the `VecDeque<f64>` and replace them in favor of a fixed array for the indicators:
 - rate_of_change
 - efficency_ratio
 - money_flow_index

But since it will not be a simple drop-in replacement, I prefer to put it in another branch named `refactor-remove_vecdeque` or something like that (easier to review) ...

Sorry for doing those 6 things in 1 commit.
I am not even sure if you will like all these changes sooooo... Tell me if you want me to split them.