### PR TITLE
Add serde support to all indicators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ install:
   - rustup component add rustfmt
   - rustup component add clippy
 script:
-  # - cargo fmt -- --check
+  - cargo fmt -- --check
   # - cargo clippy -- -D warnings
   - cargo test
   - cargo package
-jobs:
-  allow_failures:
-    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ script:
   - cargo fmt -- --check
   # - cargo clippy -- -D warnings
   - cargo test
+  - cargo test --features serde
   - cargo package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ include = [
     "README.md"
 ]
 
-[features]
-serde_support = ["serde"]
-
 [badges]
 travis-ci = { repository = "greyblake/ta-rs", branch = "master" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ assert_approx_eq = "1.0.0"
 csv = "0.15.0"
 bencher = "0.1.5"
 rand = "0.6.5"
+bincode = "1.3.1"
 
 [[bench]]
 name = "indicators"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 description = "Technical analysis library. Implements number of indicators: EMA, SMA, RSI, MACD, Stochastic, etc."
 keywords = ["technical-analysis", "financial", "ema", "indicators", "trading"]
 license = "MIT"
-repository = "https://github.com/dgunay/ta-rs"
-homepage = "https://github.com/dgunay/ta-rs"
+repository = "https://github.com/greyblake/ta-rs"
+homepage = "https://github.com/greyblake/ta-rs"
 documentation = "https://docs.rs/ta"
 readme = "README.md"
 categories = ["science", "algorithms"]
@@ -18,7 +18,7 @@ include = [
 ]
 
 [badges]
-travis-ci = { repository = "dgunay/ta-rs", branch = "master" }
+travis-ci = { repository = "greyblake/ta-rs", branch = "master" }
 
 [dependencies]
 error-chain = "0.12"

--- a/src/indicators/average_true_range.rs
+++ b/src/indicators/average_true_range.rs
@@ -73,7 +73,7 @@ impl AverageTrueRange {
     }
 }
 
-impl<'a> Next<f64> for AverageTrueRange {
+impl Next<f64> for AverageTrueRange {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/average_true_range.rs
+++ b/src/indicators/average_true_range.rs
@@ -81,7 +81,7 @@ impl Next<f64> for AverageTrueRange {
     }
 }
 
-impl<'a, T: High + Low + Close> Next<&'a T> for AverageTrueRange {
+impl<T: High + Low + Close> Next<&T> for AverageTrueRange {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/average_true_range.rs
+++ b/src/indicators/average_true_range.rs
@@ -4,7 +4,7 @@ use crate::errors::*;
 use crate::indicators::{ExponentialMovingAverage, TrueRange};
 use crate::{Close, High, Low, Next, Reset};
 
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Average true range (ATR).
@@ -56,7 +56,7 @@ use serde::{Deserialize, Serialize};
 ///         assert_approx_eq!(indicator.next(&di), atr);
 ///     }
 /// }
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct AverageTrueRange {
     true_range: TrueRange,

--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Links
 ///
-/// ![Bollinger Bands, Wikipedia](https://en.wikipedia.org/wiki/Bollinger_Bands)
+/// * [Bollinger Bands, Wikipedia](https://en.wikipedia.org/wiki/Bollinger_Bands)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct BollingerBands {

--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::StandardDeviation as Sd;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// A Bollinger Bands (BB).
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 /// # Links
 ///
 /// ![Bollinger Bands, Wikipedia](https://en.wikipedia.org/wiki/Bollinger_Bands)
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct BollingerBands {
     length: u32,

--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -96,7 +96,7 @@ impl Next<f64> for BollingerBands {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for BollingerBands {
+impl<T: Close> Next<&T> for BollingerBands {
     type Output = BollingerBandsOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/bollinger_bands.rs
+++ b/src/indicators/bollinger_bands.rs
@@ -81,7 +81,7 @@ impl BollingerBands {
     }
 }
 
-impl<'a> Next<f64> for BollingerBands {
+impl Next<f64> for BollingerBands {
     type Output = BollingerBandsOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/efficiency_ratio.rs
+++ b/src/indicators/efficiency_ratio.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::traits::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Kaufman's Efficiency Ratio (ER).
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(er.next(19.0), 0.75);
 /// ```
 
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EfficiencyRatio {
     length: u32,
     prices: VecDeque<f64>,

--- a/src/indicators/efficiency_ratio.rs
+++ b/src/indicators/efficiency_ratio.rs
@@ -86,7 +86,7 @@ impl Next<f64> for EfficiencyRatio {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for EfficiencyRatio {
+impl<T: Close> Next<&T> for EfficiencyRatio {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> f64 {

--- a/src/indicators/efficiency_ratio.rs
+++ b/src/indicators/efficiency_ratio.rs
@@ -50,7 +50,7 @@ impl EfficiencyRatio {
     }
 }
 
-impl<'a> Next<f64> for EfficiencyRatio {
+impl Next<f64> for EfficiencyRatio {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> f64 {

--- a/src/indicators/exponential_moving_average.rs
+++ b/src/indicators/exponential_moving_average.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// An exponential moving average (EMA), also known as an exponentially weighted moving average
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 /// * [Exponential moving average, Wikipedia](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average)
 ///
 
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ExponentialMovingAverage {
     length: u32,

--- a/src/indicators/exponential_moving_average.rs
+++ b/src/indicators/exponential_moving_average.rs
@@ -97,7 +97,7 @@ impl Next<f64> for ExponentialMovingAverage {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for ExponentialMovingAverage {
+impl<T: Close> Next<&T> for ExponentialMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/exponential_moving_average.rs
+++ b/src/indicators/exponential_moving_average.rs
@@ -83,7 +83,7 @@ impl ExponentialMovingAverage {
     }
 }
 
-impl<'a> Next<f64> for ExponentialMovingAverage {
+impl Next<f64> for ExponentialMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/fast_stochastic.rs
+++ b/src/indicators/fast_stochastic.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::{Maximum, Minimum};
 use crate::{Close, High, Low, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Fast stochastic oscillator.
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(stoch.next(35.0), 75.0);
 /// assert_eq!(stoch.next(15.0), 0.0);
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct FastStochastic {
     length: u32,

--- a/src/indicators/fast_stochastic.rs
+++ b/src/indicators/fast_stochastic.rs
@@ -63,7 +63,7 @@ impl FastStochastic {
     }
 }
 
-impl<'a> Next<f64> for FastStochastic {
+impl Next<f64> for FastStochastic {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/fast_stochastic.rs
+++ b/src/indicators/fast_stochastic.rs
@@ -80,7 +80,7 @@ impl Next<f64> for FastStochastic {
     }
 }
 
-impl<'a, T: High + Low + Close> Next<&'a T> for FastStochastic {
+impl<T: High + Low + Close> Next<&T> for FastStochastic {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/keltner_channel.rs
+++ b/src/indicators/keltner_channel.rs
@@ -99,7 +99,7 @@ impl Next<f64> for KeltnerChannel {
     }
 }
 
-impl<'a, T: Close + High + Low> Next<&T> for KeltnerChannel {
+impl<T: Close + High + Low> Next<&T> for KeltnerChannel {
     type Output = KeltnerChannelOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/keltner_channel.rs
+++ b/src/indicators/keltner_channel.rs
@@ -84,7 +84,7 @@ impl KeltnerChannel {
     }
 }
 
-impl<'a> Next<f64> for KeltnerChannel {
+impl Next<f64> for KeltnerChannel {
     type Output = KeltnerChannelOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/keltner_channel.rs
+++ b/src/indicators/keltner_channel.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::{AverageTrueRange, ExponentialMovingAverage};
 use crate::{Close, High, Low, Next, Reset};
+use serde::{Deserialize, Serialize};
 
 /// Keltner Channel (KC).
 ///
@@ -44,7 +45,7 @@ use crate::{Close, High, Low, Next, Reset};
 /// # Links
 ///
 /// * [Keltner channel, Wikipedia](https://en.wikipedia.org/wiki/Keltner_channel)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeltnerChannel {
     length: u32,
     multiplier: f64,
@@ -81,7 +82,7 @@ impl KeltnerChannel {
     }
 }
 
-impl Next<f64> for KeltnerChannel {
+impl<'a> Next<'a, f64> for KeltnerChannel {
     type Output = KeltnerChannelOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {
@@ -96,7 +97,7 @@ impl Next<f64> for KeltnerChannel {
     }
 }
 
-impl<T: Close + High + Low> Next<&T> for KeltnerChannel {
+impl<'a, T: Close + High + Low> Next<'a, &T> for KeltnerChannel {
     type Output = KeltnerChannelOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/keltner_channel.rs
+++ b/src/indicators/keltner_channel.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::{AverageTrueRange, ExponentialMovingAverage};
 use crate::{Close, High, Low, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Keltner Channel (KC).
@@ -46,7 +46,7 @@ use serde::{Deserialize, Serialize};
 /// # Links
 ///
 /// * [Keltner channel, Wikipedia](https://en.wikipedia.org/wiki/Keltner_channel)
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct KeltnerChannel {
     length: u32,

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -88,7 +88,7 @@ impl Next<f64> for Maximum {
     }
 }
 
-impl<'a, T: High> Next<&'a T> for Maximum {
+impl<T: High> Next<&T> for Maximum {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{High, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Returns the highest value in a given time frame.
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(max.next(4.0), 5.0);
 /// assert_eq!(max.next(8.0), 8.0);
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Maximum {
     n: usize,

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -66,7 +66,7 @@ impl Maximum {
     }
 }
 
-impl<'a> Next<f64> for Maximum {
+impl Next<f64> for Maximum {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/minimum.rs
+++ b/src/indicators/minimum.rs
@@ -66,7 +66,7 @@ impl Minimum {
     }
 }
 
-impl<'a> Next<f64> for Minimum {
+impl Next<f64> for Minimum {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/minimum.rs
+++ b/src/indicators/minimum.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{Low, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Returns the lowest value in a given time frame.
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(min.next(12.0), 10.0);
 /// assert_eq!(min.next(13.0), 11.0);
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Minimum {
     n: usize,

--- a/src/indicators/minimum.rs
+++ b/src/indicators/minimum.rs
@@ -88,7 +88,7 @@ impl Next<f64> for Minimum {
     }
 }
 
-impl<'a, T: Low> Next<&'a T> for Minimum {
+impl<T: Low> Next<&T> for Minimum {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/money_flow_index.rs
+++ b/src/indicators/money_flow_index.rs
@@ -83,7 +83,7 @@ impl MoneyFlowIndex {
     }
 }
 
-impl<'a, T: High + Low + Close + Volume> Next<&'a T> for MoneyFlowIndex {
+impl<T: High + Low + Close + Volume> Next<&T> for MoneyFlowIndex {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> f64 {

--- a/src/indicators/money_flow_index.rs
+++ b/src/indicators/money_flow_index.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{Close, High, Low, Next, Reset, Volume};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Money Flow Index (MFI).
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 /// * [Money Flow Index, Wikipedia](https://en.wikipedia.org/wiki/Money_flow_index)
 /// * [Money Flow Index, stockcharts](https://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:money_flow_index_mfi)
 
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MoneyFlowIndex {
     n: u32,

--- a/src/indicators/moving_average_convergence_divergence.rs
+++ b/src/indicators/moving_average_convergence_divergence.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::ExponentialMovingAverage as Ema;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Moving average converge divergence (MACD).
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///     (n0, n1, n2)
 /// }
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MovingAverageConvergenceDivergence {
     fast_ema: Ema,

--- a/src/indicators/moving_average_convergence_divergence.rs
+++ b/src/indicators/moving_average_convergence_divergence.rs
@@ -101,7 +101,7 @@ impl Next<f64> for MovingAverageConvergenceDivergence {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for MovingAverageConvergenceDivergence {
+impl<T: Close> Next<&T> for MovingAverageConvergenceDivergence {
     type Output = MovingAverageConvergenceDivergenceOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/moving_average_convergence_divergence.rs
+++ b/src/indicators/moving_average_convergence_divergence.rs
@@ -82,7 +82,7 @@ impl From<MovingAverageConvergenceDivergenceOutput> for (f64, f64, f64) {
     }
 }
 
-impl<'a> Next<f64> for MovingAverageConvergenceDivergence {
+impl Next<f64> for MovingAverageConvergenceDivergence {
     type Output = MovingAverageConvergenceDivergenceOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/on_balance_volume.rs
+++ b/src/indicators/on_balance_volume.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::{Close, Next, Reset, Volume};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// On Balance Volume (OBV).
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 /// * [On Balance Volume, Wikipedia](https://en.wikipedia.org/wiki/On-balance_volume)
 /// * [On Balance Volume, stockcharts](https://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:on_balance_volume_obv)
 
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct OnBalanceVolume {
     obv: f64,

--- a/src/indicators/on_balance_volume.rs
+++ b/src/indicators/on_balance_volume.rs
@@ -74,7 +74,7 @@ impl OnBalanceVolume {
     }
 }
 
-impl<'a, T: Close + Volume> Next<&'a T> for OnBalanceVolume {
+impl<T: Close + Volume> Next<&T> for OnBalanceVolume {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> f64 {

--- a/src/indicators/percentage_price_oscillator.rs
+++ b/src/indicators/percentage_price_oscillator.rs
@@ -81,7 +81,7 @@ impl From<PercentagePriceOscillatorOutput> for (f64, f64, f64) {
     }
 }
 
-impl<'a> Next<f64> for PercentagePriceOscillator {
+impl Next<f64> for PercentagePriceOscillator {
     type Output = PercentagePriceOscillatorOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/percentage_price_oscillator.rs
+++ b/src/indicators/percentage_price_oscillator.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::ExponentialMovingAverage as Ema;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Percentage Price Oscillator (PPO).
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 ///     (n0, n1, n2)
 /// }
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct PercentagePriceOscillator {
     fast_ema: Ema,

--- a/src/indicators/percentage_price_oscillator.rs
+++ b/src/indicators/percentage_price_oscillator.rs
@@ -100,7 +100,7 @@ impl Next<f64> for PercentagePriceOscillator {
     }
 }
 
-impl<'a, T: Close> Next<&T> for PercentagePriceOscillator {
+impl<T: Close> Next<&T> for PercentagePriceOscillator {
     type Output = PercentagePriceOscillatorOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/percentage_price_oscillator.rs
+++ b/src/indicators/percentage_price_oscillator.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::ExponentialMovingAverage as Ema;
 use crate::{Close, Next, Reset};
+use serde::{Deserialize, Serialize};
 
 /// Percentage Price Oscillator (PPO).
 ///
@@ -48,7 +49,7 @@ use crate::{Close, Next, Reset};
 ///     (n0, n1, n2)
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PercentagePriceOscillator {
     fast_ema: Ema,
     slow_ema: Ema,
@@ -78,7 +79,7 @@ impl From<PercentagePriceOscillatorOutput> for (f64, f64, f64) {
     }
 }
 
-impl Next<f64> for PercentagePriceOscillator {
+impl<'a> Next<'a, f64> for PercentagePriceOscillator {
     type Output = PercentagePriceOscillatorOutput;
 
     fn next(&mut self, input: f64) -> Self::Output {
@@ -97,7 +98,7 @@ impl Next<f64> for PercentagePriceOscillator {
     }
 }
 
-impl<T: Close> Next<&T> for PercentagePriceOscillator {
+impl<'a, T: Close> Next<'a, &T> for PercentagePriceOscillator {
     type Output = PercentagePriceOscillatorOutput;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/rate_of_change.rs
+++ b/src/indicators/rate_of_change.rs
@@ -61,7 +61,7 @@ impl RateOfChange {
     }
 }
 
-impl<'a> Next<f64> for RateOfChange {
+impl Next<f64> for RateOfChange {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> f64 {

--- a/src/indicators/rate_of_change.rs
+++ b/src/indicators/rate_of_change.rs
@@ -83,7 +83,7 @@ impl Next<f64> for RateOfChange {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for RateOfChange {
+impl<T: Close> Next<&T> for RateOfChange {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> f64 {

--- a/src/indicators/rate_of_change.rs
+++ b/src/indicators/rate_of_change.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::traits::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Rate of Change (ROC)
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// * [Rate of Change, Wikipedia](https://en.wikipedia.org/wiki/Momentum_(technical_analysis))
 ///
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RateOfChange {
     length: u32,

--- a/src/indicators/relative_strength_index.rs
+++ b/src/indicators/relative_strength_index.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::*;
 use crate::indicators::ExponentialMovingAverage as Ema;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The relative strength index (RSI).
@@ -68,7 +68,7 @@ use serde::{Deserialize, Serialize};
 /// * [Relative strength index (Wikipedia)](https://en.wikipedia.org/wiki/Relative_strength_index)
 /// * [RSI (Investopedia)](http://www.investopedia.com/terms/r/rsi.asp)
 ///
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RelativeStrengthIndex {
     n: u32,

--- a/src/indicators/relative_strength_index.rs
+++ b/src/indicators/relative_strength_index.rs
@@ -118,7 +118,7 @@ impl Next<f64> for RelativeStrengthIndex {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for RelativeStrengthIndex {
+impl<T: Close> Next<&T> for RelativeStrengthIndex {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/relative_strength_index.rs
+++ b/src/indicators/relative_strength_index.rs
@@ -91,7 +91,7 @@ impl RelativeStrengthIndex {
     }
 }
 
-impl<'a> Next<f64> for RelativeStrengthIndex {
+impl Next<f64> for RelativeStrengthIndex {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -92,7 +92,7 @@ impl Next<f64> for SimpleMovingAverage {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for SimpleMovingAverage {
+impl<T: Close> Next<&T> for SimpleMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -70,7 +70,7 @@ impl SimpleMovingAverage {
     }
 }
 
-impl<'a> Next<f64> for SimpleMovingAverage {
+impl Next<f64> for SimpleMovingAverage {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Simple moving average (SMA).
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// * [Simple Moving Average, Wikipedia](https://en.wikipedia.org/wiki/Moving_average#Simple_moving_average)
 ///
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct SimpleMovingAverage {
     length: u32,

--- a/src/indicators/slow_stochastic.rs
+++ b/src/indicators/slow_stochastic.rs
@@ -53,7 +53,7 @@ impl Next<f64> for SlowStochastic {
     }
 }
 
-impl<'a, T: High + Low + Close> Next<&'a T> for SlowStochastic {
+impl<T: High + Low + Close> Next<&T> for SlowStochastic {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/slow_stochastic.rs
+++ b/src/indicators/slow_stochastic.rs
@@ -45,7 +45,7 @@ impl SlowStochastic {
     }
 }
 
-impl<'a> Next<f64> for SlowStochastic {
+impl Next<f64> for SlowStochastic {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/slow_stochastic.rs
+++ b/src/indicators/slow_stochastic.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::errors::Result;
 use crate::indicators::{ExponentialMovingAverage, FastStochastic};
 use crate::{Close, High, Low, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Slow stochastic oscillator.
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(stoch.next(30.0).round(), 31.0);
 /// assert_eq!(stoch.next(55.0).round(), 77.0);
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct SlowStochastic {
     fast_stochastic: FastStochastic,

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::errors::*;
 use crate::{Close, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Standard deviation (SD).
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// * [Standard Deviation, Wikipedia](https://en.wikipedia.org/wiki/Standard_deviation)
 ///
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct StandardDeviation {
     n: u32,

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -72,7 +72,7 @@ impl StandardDeviation {
     }
 }
 
-impl<'a> Next<f64> for StandardDeviation {
+impl Next<f64> for StandardDeviation {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -103,7 +103,7 @@ impl Next<f64> for StandardDeviation {
     }
 }
 
-impl<'a, T: Close> Next<&'a T> for StandardDeviation {
+impl<T: Close> Next<&T> for StandardDeviation {
     type Output = f64;
 
     fn next(&mut self, input: &T) -> Self::Output {

--- a/src/indicators/true_range.rs
+++ b/src/indicators/true_range.rs
@@ -86,7 +86,7 @@ impl Next<f64> for TrueRange {
     }
 }
 
-impl<'a, T: High + Low + Close> Next<&'a T> for TrueRange {
+impl<T: High + Low + Close> Next<&T> for TrueRange {
     type Output = f64;
 
     fn next(&mut self, bar: &T) -> Self::Output {

--- a/src/indicators/true_range.rs
+++ b/src/indicators/true_range.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::helpers::max3;
 use crate::{Close, High, Low, Next, Reset};
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// The range of a day's trading is simply _high_ - _low_.
@@ -49,7 +49,7 @@ use serde::{Deserialize, Serialize};
 ///     }
 /// }
 /// ```
-#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct TrueRange {
     prev_close: Option<f64>,

--- a/src/indicators/true_range.rs
+++ b/src/indicators/true_range.rs
@@ -73,7 +73,7 @@ impl fmt::Display for TrueRange {
     }
 }
 
-impl<'a> Next<f64> for TrueRange {
+impl Next<f64> for TrueRange {
     type Output = f64;
 
     fn next(&mut self, input: f64) -> Self::Output {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "serde")]
-use serde::{de::DeserializeOwned, Serialize};
-
 // Indicator traits
 //
 
@@ -18,13 +15,6 @@ pub trait Reset {
 /// [MACD](indicators/struct.MovingAverageConvergenceDivergence.html) it is `(f64, f64, f64)` since
 /// MACD returns 3 values.
 ///
-#[cfg(feature = "serde")]
-pub trait Next<T>: Serialize + DeserializeOwned {
-    type Output;
-    fn next(&mut self, input: T) -> Self::Output;
-}
-
-#[cfg(not(feature = "serde"))]
 pub trait Next<T> {
     type Output;
     fn next(&mut self, input: T) -> Self::Output;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 use serde::{de::DeserializeOwned, Serialize};
 
 // Indicator traits
@@ -18,13 +18,13 @@ pub trait Reset {
 /// [MACD](indicators/struct.MovingAverageConvergenceDivergence.html) it is `(f64, f64, f64)` since
 /// MACD returns 3 values.
 ///
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 pub trait Next<T>: Serialize + DeserializeOwned {
     type Output;
     fn next(&mut self, input: T) -> Self::Output;
 }
 
-#[cfg(not(feature = "serde_support"))]
+#[cfg(not(feature = "serde"))]
 pub trait Next<T> {
     type Output;
     fn next(&mut self, input: T) -> Self::Output;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,7 +5,7 @@ extern crate ta;
 
 #[cfg(test)]
 mod test {
-    #[cfg(feature = "serde_support")]
+    #[cfg(feature = "serde")]
     mod serde {
         use ta::indicators::SimpleMovingAverage;
         use ta::Next;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,3 +2,19 @@ extern crate csv;
 extern crate ta;
 
 // TODO: implement some integration tests
+
+#[cfg(test)]
+mod test {
+    use ta::indicators::SimpleMovingAverage;
+    use ta::Next;
+
+    // Simple smoke test that serde works (not sure if this is really necessary)
+    #[test]
+    fn test_serde() {
+        let mut macd = SimpleMovingAverage::new(20).unwrap();
+        let bytes = bincode::serialize(&macd).unwrap();
+        let mut deserialized: SimpleMovingAverage = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(deserialized.next(2.0), macd.next(2.0));
+    }
+}


### PR DESCRIPTION
Figured I'd just go ahead and open the PR. Adds serde support to all indicators using `serde_derive`. 

Perhaps most importantly I changed the `Next` trait to require the implementation of Serialize and Deserialize:

```rust
pub trait Next<'a, T>: Serialize + Deserialize<'a>
```

There's only a test for one indicator but perhaps it's not even really necessary (since I imagine it would be unlikely to compile if it were broken given how `serde_derive` works).

If you would rather not bloat compilation times and maybe have it behind a feature flag or something that is totally fine, it's up to you. Thanks for maintaining this repo by the way, it was a big help for one of my projects.