### PR TITLE
Fix error in StandardDeviation

### DIFF
--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -98,6 +98,9 @@ impl Next<f64> for StandardDeviation {
             let delta2 = input - self.m + old_val - old_m;
             self.m2 += delta * delta2;
         }
+        if self.m2 < 0.0 {
+            self.m2 = 0.0;
+        }
 
         (self.m2 / self.count as f64).sqrt()
     }
@@ -157,6 +160,18 @@ mod tests {
         assert_eq!(round(sd.next(20.0)), 7.071);
         assert_eq!(round(sd.next(10.0)), 7.071);
         assert_eq!(round(sd.next(100.0)), 35.355);
+    }
+
+    #[test]
+    fn test_next_floating_point_error() {
+        let mut sd = StandardDeviation::new(6).unwrap();
+        assert_eq!(sd.next(1.872), 0.0);
+        assert_eq!(round(sd.next(1.0)), 0.436);
+        assert_eq!(round(sd.next(1.0)), 0.411);
+        assert_eq!(round(sd.next(1.0)), 0.378);
+        assert_eq!(round(sd.next(1.0)), 0.349);
+        assert_eq!(round(sd.next(1.0)), 0.325);
+        assert_eq!(round(sd.next(1.0)), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
```rust
let mut sd = StandardDeviation::new(6).unwrap();
assert_eq!(sd.next(1.872), 0.0);
assert_eq!(round(sd.next(1.0)), 0.436);
assert_eq!(round(sd.next(1.0)), 0.411);
assert_eq!(round(sd.next(1.0)), 0.378);
assert_eq!(round(sd.next(1.0)), 0.349);
assert_eq!(round(sd.next(1.0)), 0.325);
assert_eq!(round(sd.next(1.0)), 0.0);
```

Before the fix, this test failed at the last line because `sd.next(1.0)` would return `NaN`

The StandardDeviation calculation ends with `(self.m2 / self.count as f64).sqrt()`, and clearly `self.m2` should be zero when six `1.0`s are given.
But a floating-point error occurs, and `self.m2` becomes `-0.0000000000000000000000002757268708510092
` - which is a negative number, and `sqrt()` of a negative number is `NaN`.

To prevent this, `self.m2` must be set to zero if it's negative.
`self.m2` can't be negative mathematically, so if it is, then it must be zero (+floating-point error).