### PR TITLE
feat: implement Commodity Channel Index (CCI) and Mean Absolute Deviation (MAD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### Unreleased
+
+* Implement Mean Absolute Deviation (MAD)
+* Implement Commodity Channel Index (CCI)
+
 #### v0.4.0 - 2020-11-03
 
 * [breaking] Unify parameters for the indicators

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ So far there are the following indicators available.
   * Slow Stochastic
   * Moving Average Convergence Divergence (MACD)
   * Percentage Price Oscillator (PPO)
+  * Commodity Channel Index (CCI)
   * Money Flow Index (MFI)
 * Other
   * Minimum
   * Maximum
   * True Range
   * Standard Deviation (SD)
+  * Mean Absolute Deviation (MAD)
   * Average True Range (AR)
   * Efficiency Ratio (ER)
   * Bollinger Bands (BB)
@@ -112,6 +114,6 @@ cargo bench
 - [shreyasdeotare](https://github.com/shreyasdeotare) Shreyas Deotare - MoneyFlowIndex, OnBalanceVolume
 - [edwardycl](https://github.com/edwardycl) - StandardDeviation Implementation & More Efficient BollingerBands
 - [rideron89](https://github.com/rideron89) Ron Rider - Keltner Channel
-- [tirz](https://github.com/tirz) - Chandelier Exit, Percentage Price Oscillator, refactorings
+- [tirz](https://github.com/tirz) - CCI, CE, MAD, PPO, refactorings
 - [Devin Gunay](https://github.com/dgunay) - serde support
 - [Youngchan Lee](https://github.com/edwardycl) - bugfix

--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -5,10 +5,11 @@ extern crate ta;
 use bencher::Bencher;
 use rand::Rng;
 use ta::indicators::{
-    BollingerBands, ChandelierExit, EfficiencyRatio, ExponentialMovingAverage, FastStochastic,
-    KeltnerChannel, Maximum, Minimum, MoneyFlowIndex, MovingAverageConvergenceDivergence,
-    OnBalanceVolume, PercentagePriceOscillator, RateOfChange, RelativeStrengthIndex,
-    SimpleMovingAverage, SlowStochastic, StandardDeviation, TrueRange,
+    BollingerBands, ChandelierExit, CommodityChannelIndex, EfficiencyRatio,
+    ExponentialMovingAverage, FastStochastic, KeltnerChannel, Maximum, MeanAbsoluteDeviation,
+    Minimum, MoneyFlowIndex, MovingAverageConvergenceDivergence, OnBalanceVolume,
+    PercentagePriceOscillator, RateOfChange, RelativeStrengthIndex, SimpleMovingAverage,
+    SlowStochastic, StandardDeviation, TrueRange,
 };
 use ta::DataItem;
 use ta::Next;
@@ -58,6 +59,7 @@ bench_indicators!(
     SimpleMovingAverage,
     ExponentialMovingAverage,
     StandardDeviation,
+    MeanAbsoluteDeviation,
     BollingerBands,
     ChandelierExit,
     KeltnerChannel,
@@ -67,6 +69,7 @@ bench_indicators!(
     Minimum,
     MovingAverageConvergenceDivergence,
     PercentagePriceOscillator,
+    CommodityChannelIndex,
     RateOfChange,
     RelativeStrengthIndex,
     SlowStochastic,

--- a/src/indicators/commodity_channel_index.rs
+++ b/src/indicators/commodity_channel_index.rs
@@ -1,0 +1,148 @@
+use std::fmt;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::errors::Result;
+use crate::indicators::{MeanAbsoluteDeviation, SimpleMovingAverage};
+use crate::{Close, High, Low, Next, Period, Reset};
+
+/// Commodity Channel Index (CCI)
+///
+/// The commodity channel index is an oscillator originally introduced by Donald Lambert in 1980.
+///
+/// Since its introduction, the indicator has grown in popularity and is now a very common tool for
+/// traders in identifying cyclical trends not only in commodities but also equities and currencies.
+/// The CCI can be adjusted to the timeframe of the market traded on by changing the averaging period.
+///
+/// # Formula
+///
+/// CCI(_period_) = (TP - SMA(_period_) of TP) / (MAD(_period_) * 0.015)
+///
+/// # Parameters
+///
+/// * _period_ - number of periods (integer greater than 0). Default is 20.
+///
+/// # Links
+///
+/// * [Commodity Channel Index, Wikipedia](https://en.wikipedia.org/wiki/Commodity_channel_index)
+/// * [Commodity Channel Index, StockCharts](https://school.stockcharts.com/doku.php?id=technical_indicators:commodity_channel_index_cci)
+///
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct CommodityChannelIndex {
+    sma: SimpleMovingAverage,
+    mad: MeanAbsoluteDeviation,
+}
+
+impl CommodityChannelIndex {
+    pub fn new(period: usize) -> Result<Self> {
+        Ok(Self {
+            sma: SimpleMovingAverage::new(period)?,
+            mad: MeanAbsoluteDeviation::new(period)?,
+        })
+    }
+}
+
+impl Period for CommodityChannelIndex {
+    fn period(&self) -> usize {
+        self.sma.period()
+    }
+}
+
+impl<T: Close + High + Low> Next<&T> for CommodityChannelIndex {
+    type Output = f64;
+
+    fn next(&mut self, input: &T) -> Self::Output {
+        let tp = (input.close() + input.high() + input.low()) / 3.0;
+        let sma = self.sma.next(tp);
+        let mad = self.mad.next(input);
+
+        if mad == 0.0 {
+            return 0.0;
+        }
+
+        (tp - sma) / (mad * 0.015)
+    }
+}
+
+impl Reset for CommodityChannelIndex {
+    fn reset(&mut self) {
+        self.sma.reset();
+        self.mad.reset();
+    }
+}
+
+impl Default for CommodityChannelIndex {
+    fn default() -> Self {
+        Self::new(20).unwrap()
+    }
+}
+
+impl fmt::Display for CommodityChannelIndex {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CCI({})", self.sma.period())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helper::*;
+
+    #[test]
+    fn test_new() {
+        assert!(CommodityChannelIndex::new(0).is_err());
+        assert!(CommodityChannelIndex::new(1).is_ok());
+    }
+
+    #[test]
+    fn test_next_bar() {
+        let mut cci = CommodityChannelIndex::new(5).unwrap();
+
+        let bar1 = Bar::new().high(2).low(1).close(1.5);
+        assert_eq!(round(cci.next(&bar1)), 0.0);
+
+        let bar2 = Bar::new().high(5).low(3).close(4);
+        assert_eq!(round(cci.next(&bar2)), 66.667);
+
+        let bar3 = Bar::new().high(9).low(7).close(8);
+        assert_eq!(round(cci.next(&bar3)), 100.0);
+
+        let bar4 = Bar::new().high(5).low(3).close(4);
+        assert_eq!(round(cci.next(&bar4)), -13.793);
+
+        let bar5 = Bar::new().high(5).low(3).close(4);
+        assert_eq!(round(cci.next(&bar5)), -13.514);
+
+        let bar6 = Bar::new().high(2).low(1).close(1.5);
+        assert_eq!(round(cci.next(&bar6)), -126.126);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut cci = CommodityChannelIndex::new(5).unwrap();
+
+        let bar1 = Bar::new().high(2).low(1).close(1.5);
+        let bar2 = Bar::new().high(5).low(3).close(4);
+
+        assert_eq!(round(cci.next(&bar1)), 0.0);
+        assert_eq!(round(cci.next(&bar2)), 66.667);
+
+        cci.reset();
+
+        assert_eq!(round(cci.next(&bar1)), 0.0);
+        assert_eq!(round(cci.next(&bar2)), 66.667);
+    }
+
+    #[test]
+    fn test_default() {
+        CommodityChannelIndex::default();
+    }
+
+    #[test]
+    fn test_display() {
+        let indicator = CommodityChannelIndex::new(10).unwrap();
+        assert_eq!(format!("{}", indicator), "CCI(10)");
+    }
+}

--- a/src/indicators/mean_absolute_deviation.rs
+++ b/src/indicators/mean_absolute_deviation.rs
@@ -1,0 +1,168 @@
+use std::fmt;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::errors::{Error, ErrorKind, Result};
+use crate::{Close, Next, Period, Reset};
+
+/// Mean Absolute Deviation (MAD)
+///
+/// The mean absolute deviation of a data set is the average of the absolute deviations from a
+/// central point. It is a summary statistic of statistical dispersion or variability.
+/// In the general form, the central point can be a mean, median, mode, or the result of any other
+/// measure of central tendency or any random data point related to the given data set.
+/// The absolute values of the differences between the data points and their central tendency are
+/// totaled and divided by the number of data points.
+///
+/// # Formula
+///
+/// MAD(_period_) = { x<sub>1</sub> - ABS(AVG(_period_)), ..., x<sub>_period_</sub> - ABS(AVG(_period_)) } / _period_
+///
+/// # Parameters
+///
+/// * _period_ - number of periods (integer greater than 0). Default is 9.
+///
+/// # Links
+///
+/// * [Mean Absolute Deviation, Wikipedia](https://en.wikipedia.org/wiki/Mean_absolute_deviation)
+///
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
+pub struct MeanAbsoluteDeviation {
+    period: usize,
+    index: usize,
+    count: usize,
+    sum: f64,
+    deque: Box<[f64]>,
+}
+
+impl MeanAbsoluteDeviation {
+    pub fn new(period: usize) -> Result<Self> {
+        match period {
+            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            _ => Ok(Self {
+                period,
+                index: 0,
+                count: 0,
+                sum: 0.0,
+                deque: vec![0.0; period].into_boxed_slice(),
+            }),
+        }
+    }
+}
+
+impl Period for MeanAbsoluteDeviation {
+    fn period(&self) -> usize {
+        self.period
+    }
+}
+
+impl Next<f64> for MeanAbsoluteDeviation {
+    type Output = f64;
+
+    fn next(&mut self, input: f64) -> Self::Output {
+        self.sum = if self.count < self.period {
+            self.count = self.count + 1;
+            self.sum + input
+        } else {
+            self.sum + input - self.deque[self.index]
+        };
+
+        self.deque[self.index] = input;
+        self.index = if self.index + 1 < self.period {
+            self.index + 1
+        } else {
+            0
+        };
+
+        let mean = self.sum / self.count as f64;
+
+        let mut mad = 0.0;
+        for value in &self.deque[..self.count] {
+            mad += (value - mean).abs();
+        }
+        mad / self.count as f64
+    }
+}
+
+impl<T: Close> Next<&T> for MeanAbsoluteDeviation {
+    type Output = f64;
+
+    fn next(&mut self, input: &T) -> Self::Output {
+        self.next(input.close())
+    }
+}
+
+impl Reset for MeanAbsoluteDeviation {
+    fn reset(&mut self) {
+        self.index = 0;
+        self.count = 0;
+        self.sum = 0.0;
+        for i in 0..self.period {
+            self.deque[i] = 0.0;
+        }
+    }
+}
+
+impl Default for MeanAbsoluteDeviation {
+    fn default() -> Self {
+        Self::new(9).unwrap()
+    }
+}
+
+impl fmt::Display for MeanAbsoluteDeviation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MAD({})", self.period)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helper::*;
+
+    test_indicator!(MeanAbsoluteDeviation);
+
+    #[test]
+    fn test_new() {
+        assert!(MeanAbsoluteDeviation::new(0).is_err());
+        assert!(MeanAbsoluteDeviation::new(1).is_ok());
+    }
+
+    #[test]
+    fn test_next() {
+        let mut mad = MeanAbsoluteDeviation::new(5).unwrap();
+
+        assert_eq!(round(mad.next(1.5)), 0.0);
+        assert_eq!(round(mad.next(4.0)), 1.25);
+        assert_eq!(round(mad.next(8.0)), 2.333);
+        assert_eq!(round(mad.next(4.0)), 1.813);
+        assert_eq!(round(mad.next(4.0)), 1.48);
+        assert_eq!(round(mad.next(1.5)), 1.48);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut mad = MeanAbsoluteDeviation::new(5).unwrap();
+
+        assert_eq!(round(mad.next(1.5)), 0.0);
+        assert_eq!(round(mad.next(4.0)), 1.25);
+
+        mad.reset();
+
+        assert_eq!(round(mad.next(1.5)), 0.0);
+        assert_eq!(round(mad.next(4.0)), 1.25);
+    }
+
+    #[test]
+    fn test_default() {
+        MeanAbsoluteDeviation::default();
+    }
+
+    #[test]
+    fn test_display() {
+        let indicator = MeanAbsoluteDeviation::new(10).unwrap();
+        assert_eq!(format!("{}", indicator), "MAD(10)");
+    }
+}

--- a/src/indicators/mod.rs
+++ b/src/indicators/mod.rs
@@ -7,6 +7,9 @@ pub use self::simple_moving_average::SimpleMovingAverage;
 mod standard_deviation;
 pub use self::standard_deviation::StandardDeviation;
 
+mod mean_absolute_deviation;
+pub use self::mean_absolute_deviation::MeanAbsoluteDeviation;
+
 mod relative_strength_index;
 pub use self::relative_strength_index::RelativeStrengthIndex;
 
@@ -37,6 +40,9 @@ mod percentage_price_oscillator;
 pub use self::percentage_price_oscillator::{
     PercentagePriceOscillator, PercentagePriceOscillatorOutput,
 };
+
+mod commodity_channel_index;
+pub use self::commodity_channel_index::CommodityChannelIndex;
 
 mod efficiency_ratio;
 pub use self::efficiency_ratio::EfficiencyRatio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,11 @@
 //!   * [Slow Stochastic](indicators/struct.SlowStochastic.html)
 //!   * [Moving Average Convergence Divergence (MACD)](indicators/struct.MovingAverageConvergenceDivergence.html)
 //!   * [Percentage Price Oscillator (PPO)](indicators/struct.PercentagePriceOscillator.html)
+//!   * [Commodity Channel Index (CCI)](indicators/struct.CommodityChannelIndex.html)
 //!   * [Money Flow Index (MFI)](indicators/struct.MoneyFlowIndex.html)
 //! * Other
 //!   * [Standard Deviation (SD)](indicators/struct.StandardDeviation.html)
+//!   * [Mean Absolute Deviation (MAD)](indicators/struct.MeanAbsoluteDeviation.html)
 //!   * [Bollinger Bands (BB)](indicators/struct.BollingerBands.html)
 //!   * [Chandelier Exit (CE)](indicators/struct.ChandelierExit.html)
 //!   * [Keltner Channel (KC)](indicators/struct.KeltnerChannel.html)


### PR DESCRIPTION
Implement 2 indicators in 1 PR since CCI require MAD and MAD _alone_ does not have any senses in TA (hard to justify an implementation).
