### PR TITLE
fix: ER now derive Debug and Clone

### DIFF
--- a/src/indicators/efficiency_ratio.rs
+++ b/src/indicators/efficiency_ratio.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 /// ```
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct EfficiencyRatio {
     period: usize,
     index: usize,


### PR DESCRIPTION
The structure `EfficiencyRatio` is the only ones to not derive `Debug` and `Clone`.
Since it does not behave the same way that the others indicators, it can trigger an unique compile error.

So here is the illustration of the problem:

```rust
#[derive(Debug, Clone)] // <-- using it since it is allowed in all the others indicators
struct MyStruct {
    sma: SimpleMovingAverage, // <-- ok
    random: AnyOtherIndicator, // <-- replace with a real indicator and it will be ok
    er: EfficiencyRatio, // <-- compile error
}
```
