### PR TITLE
bench: add ATR

### DIFF
--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -1,17 +1,12 @@
-#[macro_use]
-extern crate bencher;
-extern crate ta;
-
-use bencher::Bencher;
+use bencher::{benchmark_group, benchmark_main, Bencher};
 use rand::Rng;
 use ta::indicators::{
-    BollingerBands, ChandelierExit, EfficiencyRatio, ExponentialMovingAverage, FastStochastic,
-    KeltnerChannel, Maximum, Minimum, MoneyFlowIndex, MovingAverageConvergenceDivergence,
-    OnBalanceVolume, PercentagePriceOscillator, RateOfChange, RelativeStrengthIndex,
-    SimpleMovingAverage, SlowStochastic, StandardDeviation, TrueRange,
+    AverageTrueRange, BollingerBands, ChandelierExit, EfficiencyRatio, ExponentialMovingAverage,
+    FastStochastic, KeltnerChannel, Maximum, Minimum, MoneyFlowIndex,
+    MovingAverageConvergenceDivergence, OnBalanceVolume, PercentagePriceOscillator, RateOfChange,
+    RelativeStrengthIndex, SimpleMovingAverage, SlowStochastic, StandardDeviation, TrueRange,
 };
-use ta::DataItem;
-use ta::Next;
+use ta::{DataItem, Next};
 
 const ITEMS_COUNT: usize = 5_000;
 
@@ -37,6 +32,7 @@ fn rand_data_item() -> DataItem {
 macro_rules! bench_indicators {
     ($($indicator:ident), *) => {
         $(
+            #[allow(non_snake_case)]
             fn $indicator(bench: &mut Bencher) {
                 let items: Vec<DataItem> = (0..ITEMS_COUNT).map( |_| rand_data_item() ).collect();
                 let mut indicator = $indicator::default();
@@ -55,22 +51,23 @@ macro_rules! bench_indicators {
 }
 
 bench_indicators!(
-    SimpleMovingAverage,
-    ExponentialMovingAverage,
-    StandardDeviation,
+    AverageTrueRange,
     BollingerBands,
     ChandelierExit,
-    KeltnerChannel,
     EfficiencyRatio,
+    ExponentialMovingAverage,
     FastStochastic,
+    KeltnerChannel,
     Maximum,
     Minimum,
+    MoneyFlowIndex,
     MovingAverageConvergenceDivergence,
+    OnBalanceVolume,
     PercentagePriceOscillator,
     RateOfChange,
     RelativeStrengthIndex,
+    SimpleMovingAverage,
     SlowStochastic,
-    TrueRange,
-    MoneyFlowIndex,
-    OnBalanceVolume
+    StandardDeviation,
+    TrueRange
 );


### PR DESCRIPTION
 - Add AverageTrueRange to the benches.
 - Remove usages of `extern crate` since we are using rust 2018.
 - Sort `bench_indicators!` list in alphabetical order (easier/faster to search for specific indicator).

Note: `#[allow(non_snake_case)]` does not work for the macro `bench_indicators!`.
It may be a bug. I will open a ticket on rust.

Sorry for posting it in parallel of https://github.com/greyblake/ta-rs/pull/37... I know that it will trigger a conflict, so I will take a break after this PR :p