### PR TITLE
Issue 44 get rid of error chain dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 travis-ci = { repository = "greyblake/ta-rs", branch = "master" }
 
 [dependencies]
-error-chain = "0.12"
 serde = { version = "1.0", features = ["derive"], optional = true}
 
 [dev-dependencies]
@@ -30,6 +29,7 @@ csv = "1.1.0"
 bencher = "0.1.5"
 rand = "0.6.5"
 bincode = "1.3.1"
+anyhow = "1.0"
 
 [[bench]]
 name = "indicators"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ csv = "1.1.0"
 bencher = "0.1.5"
 rand = "0.6.5"
 bincode = "1.3.1"
-anyhow = "1.0"
 
 [[bench]]
 name = "indicators"

--- a/src/data_item.rs
+++ b/src/data_item.rs
@@ -140,7 +140,7 @@ impl DataItemBuilder {
                 };
                 Ok(item)
             } else {
-                Err(TaError::InvalidParameter)
+                Err(TaError::DataItemInvalid)
             }
         } else {
             Err(TaError::DataItemIncomplete)

--- a/src/data_item.rs
+++ b/src/data_item.rs
@@ -140,10 +140,10 @@ impl DataItemBuilder {
                 };
                 Ok(item)
             } else {
-                Err(Error::from_kind(ErrorKind::DataItemInvalid))
+                Err(TaError::InvalidParameter)
             }
         } else {
-            Err(Error::from_kind(ErrorKind::DataItemIncomplete))
+            Err(TaError::DataItemIncomplete)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,31 @@
-error_chain! {
-    errors {
-        InvalidParameter { description("invalid parameter") }
-        DataItemIncomplete { description("data item is incomplete") }
-        DataItemInvalid { description("data item is invalid") }
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+pub type Result<T> = std::result::Result<T, TaError>;
+
+#[derive(Debug)]
+pub enum TaError {
+    InvalidParameter,
+    DataItemIncomplete,
+    DataItemInvalid,
+}
+
+impl Display for TaError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match *self {
+            TaError::InvalidParameter => write!(f, "invalid parameter"),
+            TaError::DataItemIncomplete => write!(f, "data item is incomplete"),
+            TaError::DataItemInvalid => write!(f, "data item is invalid"),
+        }
+    }
+}
+
+impl Error for TaError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            TaError::InvalidParameter => None,
+            TaError::DataItemIncomplete => None,
+            TaError::DataItemInvalid => None,
+        }
     }
 }

--- a/src/indicators/efficiency_ratio.rs
+++ b/src/indicators/efficiency_ratio.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::traits::{Close, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -42,7 +42,7 @@ pub struct EfficiencyRatio {
 impl EfficiencyRatio {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 index: 0,

--- a/src/indicators/exponential_moving_average.rs
+++ b/src/indicators/exponential_moving_average.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{Close, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ pub struct ExponentialMovingAverage {
 impl ExponentialMovingAverage {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 k: 2.0 / (period + 1) as f64,

--- a/src/indicators/maximum.rs
+++ b/src/indicators/maximum.rs
@@ -1,7 +1,7 @@
 use std::f64::INFINITY;
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{High, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -37,7 +37,7 @@ pub struct Maximum {
 impl Maximum {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 max_index: 0,

--- a/src/indicators/minimum.rs
+++ b/src/indicators/minimum.rs
@@ -1,7 +1,7 @@
 use std::f64::INFINITY;
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{Low, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -36,7 +36,7 @@ pub struct Minimum {
 impl Minimum {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 min_index: 0,

--- a/src/indicators/money_flow_index.rs
+++ b/src/indicators/money_flow_index.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{Close, High, Low, Next, Period, Reset, Volume};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,7 @@ pub struct MoneyFlowIndex {
 impl MoneyFlowIndex {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 money_flows: VecDeque::with_capacity(period + 1),

--- a/src/indicators/rate_of_change.rs
+++ b/src/indicators/rate_of_change.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::traits::{Close, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -51,7 +51,7 @@ pub struct RateOfChange {
 impl RateOfChange {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 index: 0,

--- a/src/indicators/simple_moving_average.rs
+++ b/src/indicators/simple_moving_average.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{Close, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -52,7 +52,7 @@ pub struct SimpleMovingAverage {
 impl SimpleMovingAverage {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 index: 0,

--- a/src/indicators/standard_deviation.rs
+++ b/src/indicators/standard_deviation.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::errors::{Error, ErrorKind, Result};
+use crate::errors::{Result, TaError};
 use crate::{Close, Next, Period, Reset};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -53,7 +53,7 @@ pub struct StandardDeviation {
 impl StandardDeviation {
     pub fn new(period: usize) -> Result<Self> {
         match period {
-            0 => Err(Error::from_kind(ErrorKind::InvalidParameter)),
+            0 => Err(TaError::InvalidParameter),
             _ => Ok(Self {
                 period,
                 index: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,6 @@
 //!   * [Rate of Change (ROC)](crate::indicators::RateOfChange)
 //!   * [On Balance Volume (OBV)](crate::indicators::OnBalanceVolume)
 //!
-#[macro_use]
-extern crate error_chain;
-
 #[cfg(test)]
 #[macro_use]
 mod test_helper;


### PR DESCRIPTION
fix #44 

Hi, I am a user of this wonderful library, 
and currently, I try to use [anyhow](https://docs.rs/anyhow/1.0.38/anyhow/) into my application but causing this error

```rust
E0277: `(dyn std::error::Error + std::marker::Send + 'static)` cannot be shared between threads safely  `(dyn std::e
rror::Error + std::marker::Send + 'static)` cannot be shared between threads safely  help: the trait `std::marker::S
ync` is not implemented for `(dyn std::error::Error + std::marker::Send + 'static)` note: required because of the re
quirements on the impl of `std::marker::Sync` for `std::ptr::Unique<(dyn std::error::Error + std::marker::Send + 'st
atic)>` note: required because it appears within the type `std::boxed::Box<(dyn std::error::Error + std::marker::Sen
d + 'static)>` note: required because it appears within the type `std::option::Option<std::boxed::Box<(dyn std::erro
r::Error + std::marker::Send + 'static)>>` note: required because it appears within the type `error_chain::State` no
te: required because it appears within the type `ta::errors::Error` note: required because of the requirements on th
e impl of `std::convert::From<ta::errors::Error>` for `anyhow::Error` note: required by `std::convert::From::from`
```

and seems like that error is based on this issue from [error-chain](https://github.com/rust-lang-nursery/error-chain/pull/241)

then I noticed that you opened an issue try to get rid of that library,
so that's why this PR happened.

hope you will accept it.
thank you.