### PR TITLE
build: link-time optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 travis-ci = { repository = "greyblake/ta-rs", branch = "master" }
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true}
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.0.0"
@@ -29,6 +29,9 @@ csv = "1.1.0"
 bencher = "0.1.5"
 rand = "0.6.5"
 bincode = "1.3.1"
+
+[profile.release]
+lto = true
 
 [[bench]]
 name = "indicators"


### PR DESCRIPTION
Tested with `cargo bench` on an Intel i7-6500U.

Before :
```
test AverageTrueRange                   ... bench:      83,736 ns/iter (+/- 34,005)
test BollingerBands                     ... bench:      70,263 ns/iter (+/- 44,587)
test ChandelierExit                     ... bench:     176,017 ns/iter (+/- 82,171)
test CommodityChannelIndex              ... bench:     195,135 ns/iter (+/- 40,995)
test EfficiencyRatio                    ... bench:      98,481 ns/iter (+/- 18,325)
test ExponentialMovingAverage           ... bench:      57,607 ns/iter (+/- 8,920)
test FastStochastic                     ... bench:      90,023 ns/iter (+/- 26,389)
test KeltnerChannel                     ... bench:     135,659 ns/iter (+/- 27,702)
test Maximum                            ... bench:      45,850 ns/iter (+/- 12,969)
test MeanAbsoluteDeviation              ... bench:      77,585 ns/iter (+/- 26,681)
test Minimum                            ... bench:      42,455 ns/iter (+/- 23,480)
test MoneyFlowIndex                     ... bench:     122,374 ns/iter (+/- 18,821)
test MovingAverageConvergenceDivergence ... bench:      61,473 ns/iter (+/- 6,735)
test OnBalanceVolume                    ... bench:      57,164 ns/iter (+/- 11,170)
test PercentagePriceOscillator          ... bench:      73,726 ns/iter (+/- 11,966)
test RateOfChange                       ... bench:      24,846 ns/iter (+/- 4,615)
test RelativeStrengthIndex              ... bench:      65,027 ns/iter (+/- 10,195)
test SimpleMovingAverage                ... bench:      33,234 ns/iter (+/- 19,738)
test SlowStochastic                     ... bench:     134,531 ns/iter (+/- 34,622)
test StandardDeviation                  ... bench:      58,241 ns/iter (+/- 22,669)
test TrueRange                          ... bench:      66,841 ns/iter (+/- 10,373)
```

After :
```
test AverageTrueRange                   ... bench:       1,809 ns/iter (+/- 482)
test BollingerBands                     ... bench:       5,528 ns/iter (+/- 1,885)
test ChandelierExit                     ... bench:      51,646 ns/iter (+/- 15,207)
test CommodityChannelIndex              ... bench:      35,632 ns/iter (+/- 11,252)
test EfficiencyRatio                    ... bench:       7,436 ns/iter (+/- 3,014)
test ExponentialMovingAverage           ... bench:         843 ns/iter (+/- 98)
test FastStochastic                     ... bench:      37,379 ns/iter (+/- 10,913)
test KeltnerChannel                     ... bench:       1,769 ns/iter (+/- 566)
test Maximum                            ... bench:      18,182 ns/iter (+/- 4,898)
test MeanAbsoluteDeviation              ... bench:       5,747 ns/iter (+/- 2,106)
test Minimum                            ... bench:      20,890 ns/iter (+/- 6,037)
test MoneyFlowIndex                     ... bench:      32,717 ns/iter (+/- 7,848)
test MovingAverageConvergenceDivergence ... bench:       1,752 ns/iter (+/- 453)
test OnBalanceVolume                    ... bench:         864 ns/iter (+/- 229)
test PercentagePriceOscillator          ... bench:       1,663 ns/iter (+/- 225)
test RateOfChange                       ... bench:       5,788 ns/iter (+/- 3,195)
test RelativeStrengthIndex              ... bench:       1,775 ns/iter (+/- 488)
test SimpleMovingAverage                ... bench:       4,145 ns/iter (+/- 1,438)
test SlowStochastic                     ... bench:      49,036 ns/iter (+/- 12,954)
test StandardDeviation                  ... bench:       5,330 ns/iter (+/- 1,680)
test TrueRange                          ... bench:         225 ns/iter (+/- 63)
```
