### PR TITLE
Force benchmark to use all values

### DIFF
--- a/benches/indicators.rs
+++ b/benches/indicators.rs
@@ -1,4 +1,4 @@
-use bencher::{benchmark_group, benchmark_main, Bencher};
+use bencher::{benchmark_group, benchmark_main, black_box, Bencher};
 use rand::Rng;
 use ta::indicators::{
     AverageTrueRange, BollingerBands, ChandelierExit, CommodityChannelIndex, EfficiencyRatio,
@@ -37,10 +37,10 @@ macro_rules! bench_indicators {
             fn $indicator(bench: &mut Bencher) {
                 let items: Vec<DataItem> = (0..ITEMS_COUNT).map( |_| rand_data_item() ).collect();
                 let mut indicator = $indicator::default();
-
+                
                 bench.iter(|| {
                     for item in items.iter() {
-                        indicator.next(item);
+                        black_box(indicator.next(item));
                     }
                 })
             }


### PR DESCRIPTION
I found possible issue with benchmark. Current implementation does not use intermediate values of indicators, which allows compiler to optimize out important parts of the code. Adding `black_box` to swallow intermediate values should create more meaningful results.

On my machine (MacBook M1 Pro) results before change were:
```
running 21 tests
test AverageTrueRange                   ... bench:       1,568 ns/iter (+/- 25)
test BollingerBands                     ... bench:      28,256 ns/iter (+/- 217)
test ChandelierExit                     ... bench:      20,518 ns/iter (+/- 1,071)
test CommodityChannelIndex              ... bench:      17,384 ns/iter (+/- 714)
test EfficiencyRatio                    ... bench:       6,301 ns/iter (+/- 175)
test ExponentialMovingAverage           ... bench:       1,576 ns/iter (+/- 48)
test FastStochastic                     ... bench:      20,905 ns/iter (+/- 2,581)
test KeltnerChannel                     ... bench:       1,573 ns/iter (+/- 60)
test Maximum                            ... bench:      12,220 ns/iter (+/- 1,093)
test MeanAbsoluteDeviation              ... bench:       9,410 ns/iter (+/- 304)
test Minimum                            ... bench:      11,862 ns/iter (+/- 464)
test MoneyFlowIndex                     ... bench:       9,838 ns/iter (+/- 11,488)
test MovingAverageConvergenceDivergence ... bench:       1,585 ns/iter (+/- 41)
test OnBalanceVolume                    ... bench:       1,583 ns/iter (+/- 44)
test PercentagePriceOscillator          ... bench:       1,586 ns/iter (+/- 36)
test RateOfChange                       ... bench:       3,636 ns/iter (+/- 183)
test RelativeStrengthIndex              ... bench:       1,578 ns/iter (+/- 39)
test SimpleMovingAverage                ... bench:       9,465 ns/iter (+/- 405)
test SlowStochastic                     ... bench:      22,824 ns/iter (+/- 1,711)
test StandardDeviation                  ... bench:      28,289 ns/iter (+/- 807)
test TrueRange                          ... bench:         788 ns/iter (+/- 18)
```

after change:

```
running 21 tests
test AverageTrueRange                   ... bench:      10,966 ns/iter (+/- 263)
test BollingerBands                     ... bench:      17,683 ns/iter (+/- 239)
test ChandelierExit                     ... bench:      23,028 ns/iter (+/- 816)
test CommodityChannelIndex              ... bench:      35,677 ns/iter (+/- 229)
test EfficiencyRatio                    ... bench:      31,016 ns/iter (+/- 421)
test ExponentialMovingAverage           ... bench:      10,968 ns/iter (+/- 71)
test FastStochastic                     ... bench:      22,666 ns/iter (+/- 2,778)
test KeltnerChannel                     ... bench:      11,458 ns/iter (+/- 58)
test Maximum                            ... bench:      11,814 ns/iter (+/- 758)
test MeanAbsoluteDeviation              ... bench:      14,067 ns/iter (+/- 93)
test Minimum                            ... bench:      12,739 ns/iter (+/- 1,146)
test MoneyFlowIndex                     ... bench:      27,894 ns/iter (+/- 17,340)
test MovingAverageConvergenceDivergence ... bench:      11,450 ns/iter (+/- 62)
test OnBalanceVolume                    ... bench:       8,066 ns/iter (+/- 4,364)
test PercentagePriceOscillator          ... bench:      11,594 ns/iter (+/- 32)
test RateOfChange                       ... bench:       4,102 ns/iter (+/- 69)
test RelativeStrengthIndex              ... bench:      11,297 ns/iter (+/- 101)
test SimpleMovingAverage                ... bench:       9,373 ns/iter (+/- 37)
test SlowStochastic                     ... bench:      24,119 ns/iter (+/- 2,317)
test StandardDeviation                  ... bench:      30,752 ns/iter (+/- 1,067)
test TrueRange                          ... bench:       2,804 ns/iter (+/- 28)
```